### PR TITLE
fix: AI提案承認・却下後の画面更新問題を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7989,9 +7989,9 @@
       }
     },
     "node_modules/@tsumugi-chan/client": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsumugi-chan/client/-/client-1.0.4.tgz",
-      "integrity": "sha512-OnafXCJfdbQDCkMgOgp4HWRPf/i9wTIDrrN31XjLLetXgtOm6F6vwmzKj/XWVN3g7j1yKX3Lg6d0Lp1x7bx4Ig==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@tsumugi-chan/client/-/client-1.0.6.tgz",
+      "integrity": "sha512-iRL9aKf227Xv67NT+Z9ytRykKS6agLREGf49QMJ1QUcwA7kt37IuwQD7Zp1dteJ8bLtmkPtUAXf1Los9GJ43Rg==",
       "license": "MIT"
     },
     "node_modules/@tsumugi/adapter": {
@@ -22476,7 +22476,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "@tsumugi-chan/client": "1.0.4",
+        "@tsumugi-chan/client": "1.0.6",
         "@tsumugi/adapter": "*"
       },
       "devDependencies": {

--- a/packages/adapter/api/package.json
+++ b/packages/adapter/api/package.json
@@ -35,7 +35,7 @@
     "test": "TZ=Asia/Tokyo jest"
   },
   "dependencies": {
-    "@tsumugi-chan/client": "1.0.4",
+    "@tsumugi-chan/client": "1.0.6",
     "@tsumugi/adapter": "*"
   },
   "devDependencies": {

--- a/packages/adapter/api/src/internal/types/raw-sse.types.ts
+++ b/packages/adapter/api/src/internal/types/raw-sse.types.ts
@@ -1,0 +1,42 @@
+/**
+ * バックエンドから受信する生のSSEデータの型定義
+ * snake_caseのフィールド名を持つ
+ */
+import {
+  AIStreamChunk,
+  AIProposalFeedback,
+  AIProposalResult,
+} from '@tsumugi-chan/client';
+
+// 文字列をcamelCaseからsnake_caseに変換する型
+type CamelToSnakeCase<S extends string> = S extends `${infer T}${infer U}`
+  ? `${T extends Capitalize<T> ? '_' : ''}${Lowercase<T>}${CamelToSnakeCase<U>}`
+  : S;
+
+// オブジェクトの全てのキーをsnake_caseに変換し、値も再帰的に変換する型
+type Raw<T> = T extends object
+  ? T extends (infer U)[]
+    ? Raw<U>[]
+    : T extends Date | RegExp
+      ? T
+      : {
+          [K in keyof T as CamelToSnakeCase<string & K>]: Raw<T[K]>;
+        }
+  : T;
+
+/** 生のAIStreamChunk */
+export interface RawAIStreamChunk {
+  type: AIStreamChunk['type'];
+  content: AIStreamChunk['content'];
+  tool_call: AIStreamChunk['toolCall'];
+  tool_result: AIStreamChunk['toolResult'];
+  proposal: AIStreamChunk['proposal'];
+  usage: AIStreamChunk['usage'];
+  error: AIStreamChunk['error'];
+}
+
+/** 生のAIProposalResult */
+export type RawAIProposalResult = Raw<AIProposalResult>;
+
+/** 生のAIProposalFeedback */
+export type RawAIProposalFeedback = Raw<AIProposalFeedback>;


### PR DESCRIPTION
https://github.com/takecchi/tsumugi/issues/6

- SSEストリームでのsnake_case→camelCase変換の不整合を解決
- RawAIStreamChunk, RawAIProposalResult, RawAIProposalFeedback型を追加
- parseSSEStream, parseProposalSSEResponse, toAIStreamChunkでRaw型を使用
- acceptProposal, rejectProposalでfetchSSEからの生JSONを適切に型付け
- バックエンドのsnake_caseフィールドがフロントエンドのcamelCaseに正しく変換されるように修正