### PR TITLE
feat: AIメッセージングを「支援」イメージに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tsumugi
 
-AIアシスタントを搭載した小説エディタです。
+AIがあなたの創作活動をサポートする執筆環境です。
 
 > 🚧 **プロトタイプ段階**: 基本機能は動作しますが、まだ開発中です。
 
@@ -115,6 +115,9 @@ npm run storybook
 ```bash
 # Tauriプロダクションビルド（依存パッケージのビルド含む）
 npm run build:tauri
+
+# Webプロダクションビルド（依存パッケージのビルド含む）
+npm run build:web
 
 # 全パッケージビルド
 npm run build

--- a/apps/desktop/app/root.tsx
+++ b/apps/desktop/app/root.tsx
@@ -49,11 +49,11 @@ export const links: LinksFunction = () => [
 
 export const meta: MetaFunction = () => {
   return [
-    { title: 'Tsumugi - AI小説執筆支援ツール' },
+    { title: 'Tsumugi - AIがサポートする創作支援ツール' },
     {
       name: 'description',
       content:
-        'Tsumugiは小説やストーリー執筆を支援するツールです。プロット管理、キャラクター設定、執筆進捗管理など、創作活動に必要な機能を提供します。',
+        'TsumugiはAIがあなたの創作活動をサポートする執筆環境です。プロット管理、キャラクター設定、執筆進捗管理など、創作に必要な機能をAIと共に活用できます。',
     },
     {
       name: 'keywords',

--- a/apps/desktop/app/routes/(private)/home/page.tsx
+++ b/apps/desktop/app/routes/(private)/home/page.tsx
@@ -88,7 +88,7 @@ export default function Page() {
               <div>
                 <h1 className="text-lg font-bold text-foreground">Tsumugi</h1>
                 <p className="text-xs text-muted-foreground">
-                  AI小説執筆エディタ
+                  AIがサポートする創作支援ツール
                 </p>
               </div>
             </div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tsumugi",
   "version": "1.0.0",
   "packageManager": "npm@11.6.4",
-  "description": "AI Novel Studio",
+  "description": "AI-Powered Creative Writing Assistant",
   "keywords": [],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## 概要
「AI小説執筆エディタ」などの文言を、AIが書くのではなく支援するイメージに変更しました。

## 変更内容
- **ホームページ**: 「AI小説執筆エディタ」→「AIがサポートする創作支援ツール」
- **README**: 「AIアシスタントを搭載した小説エディタ」→「AIがあなたの創作活動をサポートする執筆環境」
- **package.json**: 「AI Novel Studio」→「AI-Powered Creative Writing Assistant」
- **root.tsx**: タイトルと説明文をAIが支援するイメージに統一

## 理由
「AI小説執筆エディタ」だとAIが書くというイメージが強いため、ユーザーの創作活動をAIがサポートするという適切なイメージに修正しました。