### PR TITLE
iOSのテキスト入力時のオートズームを無効化

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -125,3 +125,12 @@
     cursor: pointer;
   }
 }
+
+/* iOS Safari: font-size < 16px の input にフォーカスすると自動ズームされるのを防止 */
+@supports (-webkit-touch-callout: none) {
+  input,
+  textarea,
+  select {
+    font-size: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary

- `@supports (-webkit-touch-callout: none)` を使い、iOS Safari のみを対象に
  `input`, `textarea`, `select` の `font-size` を `1rem` (16px) に設定
- iOS Safari では font-size が 16px 未満の入力欄をタップすると自動ズームが発生するため、これを防止
- macOS Safari やその他ブラウザには一切影響なし