### PR TITLE
feat: 本文/整合性チェックの切り替えをAI属性バー右端に統合

### DIFF
--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/node-attributes-bar.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/node-attributes-bar.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { NodeAiAttributes } from '@tsumugi/ui';
 import { useUpdateNodeAttributes } from '~/hooks/nodes';
 import type { CanonStatus, ContentType, ContextPolicy } from '@tsumugi/adapter';
@@ -8,11 +9,14 @@ interface NodeAttributesBarProps {
   nodeId: string;
   canonStatus: CanonStatus;
   contextPolicy: ContextPolicy;
+  /** バー右端に配置する追加コントロール（例: 本文/整合性チェックの切り替え） */
+  children?: ReactNode;
 }
 
 /**
  * エディタ上部に表示する、ノードのAI属性（確定/検討中・AIへの見せ方）の操作バー。
  * 変更は adapter.nodes.updateAttributes 経由で保存し、対応するツリーを再フェッチする。
+ * children を渡すとバー右端に配置される。
  */
 export function NodeAttributesBar({
   projectId,
@@ -20,6 +24,7 @@ export function NodeAttributesBar({
   nodeId,
   canonStatus,
   contextPolicy,
+  children,
 }: NodeAttributesBarProps) {
   const { trigger, isMutating } = useUpdateNodeAttributes(
     projectId,
@@ -39,6 +44,9 @@ export function NodeAttributesBar({
           void trigger({ nodeId, attributes: { contextPolicy: policy } });
         }}
       />
+      {children ? (
+        <div className="ml-auto flex items-center">{children}</div>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/writing-editor-wrapper.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/writing-editor-wrapper.tsx
@@ -69,31 +69,30 @@ export function WritingEditorWrapper({
   if (!writing) return null;
 
   return (
-    <div className="flex h-full flex-col">
+    <Tabs defaultValue="body" className="flex h-full min-h-0 flex-col gap-0">
       <NodeAttributesBar
         projectId={projectId}
         contentType="writing"
         nodeId={id}
         canonStatus={writing.canonStatus}
         contextPolicy={writing.contextPolicy}
-      />
-      <Tabs defaultValue="body" className="flex min-h-0 flex-1 flex-col">
-        <TabsList className="mx-3 mt-2 self-start">
+      >
+        <TabsList className="h-7">
           <TabsTrigger value="body">本文</TabsTrigger>
           <TabsTrigger value="consistency">整合性チェック</TabsTrigger>
         </TabsList>
-        <TabsContent value="body" className="min-h-0 flex-1">
-          <WritingEditor
-            name={writing.name}
-            content={writing.content}
-            onNameChange={handleNameChange}
-            onContentChange={handleContentChange}
-          />
-        </TabsContent>
-        <TabsContent value="consistency" className="min-h-0 flex-1">
-          <ConsistencyPanelWrapper writingId={id} projectId={projectId} />
-        </TabsContent>
-      </Tabs>
-    </div>
+      </NodeAttributesBar>
+      <TabsContent value="body" className="min-h-0 flex-1">
+        <WritingEditor
+          name={writing.name}
+          content={writing.content}
+          onNameChange={handleNameChange}
+          onContentChange={handleContentChange}
+        />
+      </TabsContent>
+      <TabsContent value="consistency" className="min-h-0 flex-1">
+        <ConsistencyPanelWrapper writingId={id} projectId={projectId} />
+      </TabsContent>
+    </Tabs>
   );
 }


### PR DESCRIPTION
## 概要

writing エディタで別段に左寄せされていた「本文 / 整合性チェック」の切り替えタブを、「AIへの見せ方」などを表示する上部の AI 属性バー（`NodeAttributesBar`）の**右端**へ移動し、同一セクションに統合しました。

### Before
```
┌─────────────────────────────────────────────┐
│ [確定/検討中] | AIへの見せ方: [自動…▾]        │ ← NodeAttributesBar
├─────────────────────────────────────────────┤
│ [本文][整合性チェック]                        │ ← 別段に左寄せ
│ 本文エディタ…                                 │
```

### After
```
┌───────────────────────────────────────────────────────────┐
│ [確定/検討中] | AIへの見せ方: [自動…▾]   [本文][整合性チェック] │ ← 同一バー・右端
├───────────────────────────────────────────────────────────┤
│ 本文エディタ…                                               │
```

## 変更内容

- **`node-attributes-bar.tsx`**: バー右端スロット用の `children?: ReactNode` を追加。渡された場合のみ `ml-auto` で右端に配置。未指定時は従来どおり右側は空。
- **`writing-editor-wrapper.tsx`**: 全体を `<Tabs>` でラップ（Radix Tabs は `TabsList` / `TabsContent` が同一 `Tabs` コンテキストを共有する必要があるため）。`TabsList` を `NodeAttributesBar` の children として渡し、バーの `h-7` コントロールに合わせて `h-7` でコンパクトに揃えた。

## 影響範囲

- 「本文 / 整合性チェック」タブがあるのは writing エディタのみのため、統合は writing エディタにのみ影響。
- `NodeAttributesBar` を利用する plot / memo / character の 3 か所は `children` を渡していないため**非破壊**（従来どおり右側は空）。

## Test plan

- [ ] writing エディタで「本文」「整合性チェック」タブがバー右端に表示され、切り替えできること
- [ ] 「確定/検討中」「AIへの見せ方」が従来どおり左側に表示・操作できること
- [ ] plot / memo / character エディタの属性バーが従来どおり表示されること（右側は空のまま）
- [ ] 本文エディタ / 整合性チェックパネルが下部に正しく表示され、高さいっぱいに広がること
