### PR TITLE
fix: 正典ステータスをトグルスイッチ化し切り替えを即時反映する

### DIFF
--- a/apps/desktop/app/hooks/nodes.ts
+++ b/apps/desktop/app/hooks/nodes.ts
@@ -1,7 +1,8 @@
 import { useAdapter } from '~/hooks/useAdapter';
+import { useSWRConfig } from 'swr';
 import useSWRMutation from 'swr/mutation';
 import type { ContentType, Node, NodeAttributes } from '@tsumugi/adapter';
-import type { ContentTreeKey } from '~/hooks/keys';
+import type { ContentItemKey, ContentTreeKey } from '~/hooks/keys';
 
 interface UpdateNodeAttributesArg {
   nodeId: string;
@@ -9,20 +10,76 @@ interface UpdateNodeAttributesArg {
 }
 
 /**
+ * AI属性の変更を、個別コンテンツのキャッシュにマージする。
+ *
+ * 個別コンテンツ（Writing 等）固有のフィールド（本文など）は保持し、
+ * 指定された属性のみを差し替える。再フェッチではなくマージすることで、
+ * 編集中の未保存テキストを巻き戻さない。
+ */
+function mergeNodeAttributes<T extends Node>(
+  current: T,
+  attributes: NodeAttributes,
+): T {
+  return {
+    ...current,
+    canonStatus: attributes.canonStatus ?? current.canonStatus,
+    contextPolicy: attributes.contextPolicy ?? current.contextPolicy,
+  };
+}
+
+/**
+ * サーバーが返したノードのAI属性・更新日時を、個別コンテンツのキャッシュに取り込む。
+ */
+function applyUpdatedNode<T extends Node>(current: T, updated: Node): T {
+  return {
+    ...mergeNodeAttributes(current, {
+      canonStatus: updated.canonStatus,
+      contextPolicy: updated.contextPolicy,
+    }),
+    updatedAt: updated.updatedAt,
+  };
+}
+
+/**
  * ノードのAI属性（canonStatus / contextPolicy）を更新する。
  *
- * 更新後は対応するコンテンツツリーを再フェッチし、ツリー上の表示（確定/検討中・見せ方）を更新する。
+ * 個別コンテンツのキャッシュは楽観更新で即座に反映し、サーバー応答後にその値で確定させる
+ * （失敗時は再フェッチせずロールバックするため、編集中の未保存テキストを巻き戻さない）。
+ * あわせて対応するコンテンツツリーを再フェッチし、ツリー上の表示も更新する。
  * @param projectId - プロジェクトID
- * @param contentType - ノードのコンテンツ種別（再フェッチするツリーの特定に使用）
+ * @param contentType - ノードのコンテンツ種別（更新するキャッシュの特定に使用）
  * @revalidates use{Plot,Character,Memo,Writing}Tree - 対応するコンテンツツリーを再フェッチする
+ * @revalidates use{Plot,Character,Memo,Writing} - 個別コンテンツのキャッシュをマージ更新する（再フェッチはしない）
  */
 export function useUpdateNodeAttributes(
   projectId: string,
   contentType: ContentType,
 ) {
   const adapter = useAdapter();
+  const { mutate } = useSWRConfig();
+
   return useSWRMutation<Node, Error, ContentTreeKey, UpdateNodeAttributesArg>(
     { type: `${contentType}Tree`, projectId },
-    (_, { arg }) => adapter.nodes.updateAttributes(arg.nodeId, arg.attributes),
+    async (_, { arg }) => {
+      const itemKey: ContentItemKey = { type: contentType, id: arg.nodeId };
+      const request = adapter.nodes.updateAttributes(
+        arg.nodeId,
+        arg.attributes,
+      );
+
+      await mutate<Node | null | undefined>(
+        itemKey,
+        async (current) =>
+          current ? applyUpdatedNode(current, await request) : current,
+        {
+          optimisticData: (current) =>
+            current ? mergeNodeAttributes(current, arg.attributes) : current,
+          rollbackOnError: true,
+          revalidate: false,
+        },
+      );
+
+      return request;
+    },
   );
 }

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/node-attributes-bar.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/node-attributes-bar.tsx
@@ -1,7 +1,12 @@
 import type { ReactNode } from 'react';
 import { NodeAiAttributes } from '@tsumugi/ui';
 import { useUpdateNodeAttributes } from '~/hooks/nodes';
-import type { CanonStatus, ContentType, ContextPolicy } from '@tsumugi/adapter';
+import type {
+  CanonStatus,
+  ContentType,
+  ContextPolicy,
+  NodeAttributes,
+} from '@tsumugi/adapter';
 
 interface NodeAttributesBarProps {
   projectId: string;
@@ -31,18 +36,23 @@ export function NodeAttributesBar({
     contentType,
   );
 
+  const updateAttributes = (attributes: NodeAttributes) => {
+    trigger({ nodeId, attributes }).catch((e: unknown) => {
+      // 失敗時はキャッシュがロールバックされ、表示が元の値に戻る
+      console.error('Failed to update node attributes:', e);
+    });
+  };
+
   return (
     <div className="flex shrink-0 items-center border-b bg-background px-3 py-1.5">
       <NodeAiAttributes
         canonStatus={canonStatus}
         contextPolicy={contextPolicy}
         disabled={isMutating}
-        onCanonStatusChange={(status) => {
-          void trigger({ nodeId, attributes: { canonStatus: status } });
-        }}
-        onContextPolicyChange={(policy) => {
-          void trigger({ nodeId, attributes: { contextPolicy: policy } });
-        }}
+        onCanonStatusChange={(canonStatus) => updateAttributes({ canonStatus })}
+        onContextPolicyChange={(contextPolicy) =>
+          updateAttributes({ contextPolicy })
+        }
       />
       {children ? (
         <div className="ml-auto flex items-center">{children}</div>

--- a/packages/ui/src/components/features/node-ai-attributes/node-ai-attributes.stories.tsx
+++ b/packages/ui/src/components/features/node-ai-attributes/node-ai-attributes.stories.tsx
@@ -18,7 +18,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    canonStatus: 'draft',
+    canonStatus: 'confirmed',
     contextPolicy: 'auto',
   },
 };
@@ -27,6 +27,13 @@ export const Empty: Story = {
   args: {
     canonStatus: 'draft',
     contextPolicy: 'never',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    canonStatus: 'draft',
+    contextPolicy: 'auto',
     disabled: true,
   },
 };

--- a/packages/ui/src/components/features/node-ai-attributes/node-ai-attributes.tsx
+++ b/packages/ui/src/components/features/node-ai-attributes/node-ai-attributes.tsx
@@ -7,6 +7,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
+import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 
 export type CanonStatus = 'confirmed' | 'draft';
@@ -20,14 +21,6 @@ export interface NodeAiAttributesProps {
   disabled?: boolean;
   className?: string;
 }
-
-const CANON_STATUS_META: Record<
-  CanonStatus,
-  { label: string; dotClassName: string }
-> = {
-  confirmed: { label: '確定', dotClassName: 'bg-green-500' },
-  draft: { label: '検討中', dotClassName: 'bg-amber-500' },
-};
 
 const CONTEXT_POLICY_OPTIONS: {
   value: ContextPolicy;
@@ -48,22 +41,33 @@ function CanonStatusToggle({
   onChange?: (status: CanonStatus) => void;
   disabled?: boolean;
 }) {
-  const meta = CANON_STATUS_META[status];
-  const next: CanonStatus = status === 'confirmed' ? 'draft' : 'confirmed';
+  const id = React.useId();
+  const confirmed = status === 'confirmed';
+  const hint = 'オンにすると「確定」、オフのままだと「検討中」として扱われます';
 
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      disabled={disabled}
-      onClick={() => onChange?.(next)}
-      className="h-7 gap-1.5 px-2 text-xs font-medium"
-      title={`クリックで「${CANON_STATUS_META[next].label}」に切り替え`}
-    >
-      <span className={cn('size-2 rounded-full', meta.dotClassName)} />
-      {meta.label}
-    </Button>
+    <div className="flex items-center gap-1.5">
+      <Switch
+        id={id}
+        checked={confirmed}
+        disabled={disabled}
+        title={hint}
+        onCheckedChange={(checked) =>
+          onChange?.(checked ? 'confirmed' : 'draft')
+        }
+      />
+      <label
+        htmlFor={id}
+        title={hint}
+        className={cn(
+          'cursor-pointer text-xs font-medium select-none',
+          confirmed ? 'text-foreground' : 'text-muted-foreground',
+          disabled && 'cursor-not-allowed opacity-50',
+        )}
+      >
+        確定
+      </label>
+    </div>
   );
 }
 
@@ -141,6 +145,8 @@ function ContextPolicySelector({
 /**
  * ノードのAI属性（正典ステータス・コンテキストの見せ方）を操作する
  * コンパクトなインラインコントロール行。エディタのツールバー等に配置する。
+ *
+ * 正典ステータスは「確定」ラベル付きのトグルスイッチで表現する（オフ = 検討中）。
  */
 export function NodeAiAttributes({
   canonStatus,

--- a/packages/ui/src/components/ui/index.ts
+++ b/packages/ui/src/components/ui/index.ts
@@ -9,6 +9,7 @@ export * from './resizable';
 export * from './scroll-area';
 export * from './separator';
 export * from './skeleton';
+export * from './switch';
 export * from './tabs';
 export * from './markdown';
 export * from './sheet';

--- a/packages/ui/src/components/ui/switch.stories.tsx
+++ b/packages/ui/src/components/ui/switch.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Switch } from './switch';
+
+const meta = {
+  title: 'UI/Switch',
+  component: Switch,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    defaultChecked: true,
+    'aria-label': '確定',
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    defaultChecked: false,
+    'aria-label': '確定',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    checked: false,
+    disabled: true,
+    'aria-label': '確定',
+  },
+};
+
+export const Interactive: StoryObj = {
+  render: () => {
+    const [checked, setChecked] = useState(false);
+
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Switch
+            id="canon-status"
+            checked={checked}
+            onCheckedChange={setChecked}
+          />
+          <label htmlFor="canon-status" className="text-xs font-medium">
+            確定
+          </label>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          checked: {String(checked)}
+        </p>
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Switch as SwitchPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+export function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        'peer inline-flex h-[1.15rem] w-8 shrink-0 cursor-pointer items-center rounded-full border border-transparent shadow-xs transition-colors outline-none',
+        'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80',
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          'pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform',
+          'data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
+          'dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground',
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}


### PR DESCRIPTION
closes #37

- 確定/検討中を表す1つのボタンを「確定」ラベル + トグルスイッチに変更し、
  現在の状態と操作方法が一目で分かるようにした
- packages/ui に shadcn/Radix ベースの Switch コンポーネントを追加（story付き）
- useUpdateNodeAttributes が個別コンテンツのSWRキャッシュを更新していなかったため
  リロードするまで表示が切り替わらなかった問題を修正。
  楽観更新 → サーバー応答でマージ確定（失敗時はロールバック）に変更し、
  再フェッチではなくマージすることで編集中の未保存テキストを巻き戻さないようにした
- 更新失敗時に unhandled rejection になっていたためエラーハンドリングを追加
