### PR TITLE
feat: フィードバック送信API(POST /v1/feedback)に対応しホームに送信フォームを追加

### DIFF
--- a/apps/desktop/app/hooks/feedback.ts
+++ b/apps/desktop/app/hooks/feedback.ts
@@ -1,0 +1,23 @@
+import useSWRMutation from 'swr/mutation';
+import type { CreateFeedbackData, ProductSignal } from '@tsumugi/adapter';
+import { useAdapter } from '~/hooks/useAdapter';
+
+interface FeedbackKey {
+  type: 'feedback';
+}
+
+/**
+ * プロダクトへの要望・不満を送信する
+ *
+ * 返り値の `summary` はサーバー側で伏字化・280文字への切り詰めが行われた結果なので、
+ * 送信した文章とは一致しない。「送った内容」としてそのまま表示しないこと。
+ *
+ * @revalidates なし - 送信専用で一覧を取得する hook が無いため、再フェッチしない
+ */
+export function useSubmitFeedback() {
+  const adapter = useAdapter();
+  return useSWRMutation<ProductSignal, Error, FeedbackKey, CreateFeedbackData>(
+    { type: 'feedback' },
+    (_, { arg }) => adapter.feedback.send(arg),
+  );
+}

--- a/apps/desktop/app/routes/(private)/home/_components/feedback-dialog.tsx
+++ b/apps/desktop/app/routes/(private)/home/_components/feedback-dialog.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  FeedbackForm,
+} from '@tsumugi/ui';
+import { useSubmitFeedback } from '~/hooks/feedback';
+
+export interface FeedbackDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * どの画面・機能についての要望か（集計軸）。
+   *
+   * ドット区切りで命名を揃える（例: `home.feedback`, `ai.chat`）。
+   * 画面側で自動付与し、ユーザーには入力させない。
+   */
+  surface: string;
+}
+
+/**
+ * 要望・不満を送るダイアログ
+ */
+export function FeedbackDialog({
+  open,
+  onOpenChange,
+  surface,
+}: FeedbackDialogProps) {
+  const { trigger, isMutating } = useSubmitFeedback();
+  const [savedSummary, setSavedSummary] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // DialogContent は閉じるとアンマウントされるため、下書きはここで保持する
+  const [draft, setDraft] = useState('');
+
+  const handleSubmit = async (summary: string) => {
+    setError(null);
+    try {
+      const signal = await trigger({ surface, summary });
+      if (signal) {
+        setSavedSummary(signal.summary);
+        setDraft('');
+      } else {
+        // trigger は後続の trigger に追い越されると undefined を返す
+        setError('送信が中断されました。もう一度お試しください。');
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(`送信に失敗しました: ${message}`);
+    }
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    // 閉じている間に遅れて届いたレスポンスが次回に持ち越されないよう、
+    // 開くタイミングで状態をリセットする（閉じる際に消すと閉じるアニメ中に
+    // 入力フォームが一瞬見えてしまう）
+    if (next) {
+      setSavedSummary(null);
+      setError(null);
+    }
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>ご意見・ご要望</DialogTitle>
+          <DialogDescription>
+            使っていて困ったこと・ほしい機能を教えてください。今後の開発の参考にします。
+          </DialogDescription>
+        </DialogHeader>
+        <FeedbackForm
+          defaultValue={draft}
+          onValueChange={setDraft}
+          isSubmitting={isMutating}
+          savedSummary={savedSummary}
+          error={error}
+          onSubmit={(summary) => void handleSubmit(summary)}
+          onCancel={() => handleOpenChange(false)}
+          onReset={() => {
+            setSavedSummary(null);
+            setError(null);
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/app/routes/(private)/home/page.tsx
+++ b/apps/desktop/app/routes/(private)/home/page.tsx
@@ -19,8 +19,9 @@ import {
   Input,
 } from '@tsumugi/ui';
 import type { ProjectItem } from '@tsumugi/ui';
-import { PlusIcon, LogOutIcon } from 'lucide-react';
+import { PlusIcon, LogOutIcon, MessageSquarePlusIcon } from 'lucide-react';
 import { PATH_WORKSPACE } from '~/constants/path';
+import { FeedbackDialog } from './_components/feedback-dialog';
 
 export const meta: MetaFunction = () => [
   { title: 'Tsumugi - プロジェクト一覧' },
@@ -55,6 +56,7 @@ export default function Page() {
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(
     null,
   );
+  const [isFeedbackDialogOpen, setIsFeedbackDialogOpen] = useState(false);
 
   const handleOpenCreateDialog = () => {
     setNewProjectTitle('untitled');
@@ -131,15 +133,25 @@ export default function Page() {
                 </p>
               </div>
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => void logout()}
-              disabled={isLoggingOut}
-            >
-              <LogOutIcon className="mr-2 size-4" />
-              {isLoggingOut ? 'ログアウト中...' : 'ログアウト'}
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsFeedbackDialogOpen(true)}
+              >
+                <MessageSquarePlusIcon className="mr-2 size-4" />
+                ご意見・ご要望
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void logout()}
+                disabled={isLoggingOut}
+              >
+                <LogOutIcon className="mr-2 size-4" />
+                {isLoggingOut ? 'ログアウト中...' : 'ログアウト'}
+              </Button>
+            </div>
           </div>
           {error && (
             <div className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
@@ -168,6 +180,12 @@ export default function Page() {
           </div>
         </div>
       </div>
+
+      <FeedbackDialog
+        open={isFeedbackDialogOpen}
+        onOpenChange={setIsFeedbackDialogOpen}
+        surface="home.feedback"
+      />
 
       <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
         <DialogContent showCloseButton={false}>

--- a/packages/adapter/api/src/adapter.ts
+++ b/packages/adapter/api/src/adapter.ts
@@ -13,6 +13,7 @@ import { createConsistencyAdapter } from '@/adapters/consistency';
 import { createGlossaryAdapter } from '@/adapters/glossary';
 import { createInstructionAdapter } from '@/adapters/instruction';
 import { createExportAdapter } from '@/adapters/export';
+import { createFeedbackAdapter } from '@/adapters/feedback';
 import { TokenManager } from '@/token-manager';
 
 export function createAdapter(config: AdapterConfig = {}): Adapter {
@@ -43,5 +44,6 @@ export function createAdapter(config: AdapterConfig = {}): Adapter {
     glossary: createGlossaryAdapter(clients),
     instructions: createInstructionAdapter(clients),
     export: createExportAdapter(clients),
+    feedback: createFeedbackAdapter(clients),
   };
 }

--- a/packages/adapter/api/src/adapters/feedback.ts
+++ b/packages/adapter/api/src/adapters/feedback.ts
@@ -1,0 +1,24 @@
+import type {
+  CreateFeedbackData,
+  FeedbackAdapter,
+  ProductSignal,
+} from '@tsumugi/adapter';
+import type { ApiClients } from '@/client';
+import {
+  toCreateProductSignalRequest,
+  toProductSignal,
+} from '@/internal/helpers/feedback';
+
+/**
+ * フィードバック送信アダプター（API版）
+ */
+export function createFeedbackAdapter(clients: ApiClients): FeedbackAdapter {
+  return {
+    async send(data: CreateFeedbackData): Promise<ProductSignal> {
+      const signal = await clients.feedback.createFeedback({
+        createProductSignalRequest: toCreateProductSignalRequest(data),
+      });
+      return toProductSignal(signal);
+    },
+  };
+}

--- a/packages/adapter/api/src/client.ts
+++ b/packages/adapter/api/src/client.ts
@@ -11,6 +11,7 @@ import {
   ConsistencyApi,
   GlossaryApi,
   InstructionsApi,
+  FeedbackApi,
 } from '@tsumugi-chan/client';
 import type { TokenManager } from '@/token-manager';
 
@@ -26,6 +27,7 @@ export interface ApiClients {
   readonly consistency: ConsistencyApi;
   readonly glossary: GlossaryApi;
   readonly instructions: InstructionsApi;
+  readonly feedback: FeedbackApi;
   readonly configuration: Configuration;
 }
 
@@ -49,6 +51,7 @@ export function createApiClients(
     consistency: new ConsistencyApi(configuration),
     glossary: new GlossaryApi(configuration),
     instructions: new InstructionsApi(configuration),
+    feedback: new FeedbackApi(configuration),
     configuration,
   };
 }

--- a/packages/adapter/api/src/internal/helpers/feedback.spec.ts
+++ b/packages/adapter/api/src/internal/helpers/feedback.spec.ts
@@ -1,0 +1,213 @@
+import type { ProductSignal as ApiProductSignal } from '@tsumugi-chan/client';
+import type { CreateFeedbackData } from '@tsumugi/adapter';
+import {
+  FEEDBACK_SUMMARY_MAX_LENGTH,
+  FEEDBACK_SURFACE_MAX_LENGTH,
+  countChars,
+  normalizeFeedbackText,
+  normalizeSurface,
+  toCreateProductSignalRequest,
+  toProductSignal,
+} from './feedback';
+
+describe('countChars', () => {
+  it('BMP内の文字はそのまま数える', () => {
+    expect(countChars('あいうえお')).toBe(5);
+  });
+
+  it('サロゲートペア（絵文字）を1文字として数える', () => {
+    // String.length では 2 になる
+    expect('🎉'.length).toBe(2);
+    expect(countChars('🎉')).toBe(1);
+  });
+
+  it('空文字は0', () => {
+    expect(countChars('')).toBe(0);
+  });
+});
+
+describe('normalizeFeedbackText', () => {
+  it('前後の空白を落とす', () => {
+    expect(normalizeFeedbackText('  要望です  ')).toBe('要望です');
+  });
+
+  it('CRLF / CR を LF に統一する', () => {
+    expect(normalizeFeedbackText('1行目\r\n2行目\r3行目')).toBe(
+      '1行目\n2行目\n3行目',
+    );
+  });
+
+  it('改行は保持する', () => {
+    expect(normalizeFeedbackText('1行目\n2行目')).toBe('1行目\n2行目');
+  });
+
+  it('改行以外の制御文字を除去する', () => {
+    const withControls = `a${String.fromCharCode(0)}b${String.fromCharCode(7)}c\td`;
+    expect(normalizeFeedbackText(withControls)).toBe('abcd');
+  });
+
+  it('空白のみの入力は空文字になる', () => {
+    expect(normalizeFeedbackText('   \n\t  ')).toBe('');
+  });
+
+  it('制御文字のみの入力は空文字になる', () => {
+    const onlyControls = `${String.fromCharCode(0)}${String.fromCharCode(1)}`;
+    expect(normalizeFeedbackText(onlyControls)).toBe('');
+  });
+});
+
+describe('normalizeSurface', () => {
+  it('前後の空白を落とす', () => {
+    expect(normalizeSurface('  ai.chat  ')).toBe('ai.chat');
+  });
+
+  it('内部の空白は残す（検証側で弾くため黙って繋げない）', () => {
+    expect(normalizeSurface('ai chat')).toBe('ai chat');
+  });
+});
+
+describe('toCreateProductSignalRequest', () => {
+  it('surface と summary のみを持つオブジェクトを返す', () => {
+    const request = toCreateProductSignalRequest({
+      surface: 'ai.chat',
+      summary: 'チャットが遅いです',
+    });
+
+    expect(request).toEqual({
+      surface: 'ai.chat',
+      summary: 'チャットが遅いです',
+    });
+  });
+
+  it('kind / evidence を含まない（含めると400になるため）', () => {
+    // 余分なフィールドを持つオブジェクトを作る。
+    // 変数に代入してから返すことで、余剰プロパティチェックを通さずに
+    // 「実行時に余分なフィールドを持つ入力」を構造的に再現する（キャスト不要）。
+    const buildDataWithExtraFields = (): CreateFeedbackData => {
+      const withExtras = {
+        surface: 'plots.create',
+        summary: 'プロット作成が使いにくい',
+        kind: 'friction',
+        evidence: ['作品本文が混入したエビデンス'],
+      };
+      return withExtras;
+    };
+
+    const request = toCreateProductSignalRequest(buildDataWithExtraFields());
+
+    // スプレッドで組み立てる実装（`{ ...data, surface, summary }`）だと
+    // ここで kind / evidence が漏れて落ちる
+    expect(Object.keys(request).sort()).toEqual(['summary', 'surface']);
+    expect(request).toEqual({
+      surface: 'plots.create',
+      summary: 'プロット作成が使いにくい',
+    });
+  });
+
+  it('正規化された値を送る', () => {
+    const request = toCreateProductSignalRequest({
+      surface: '  ai.chat  ',
+      summary: '  要望です\r\nもう一つ  ',
+    });
+
+    expect(request.surface).toBe('ai.chat');
+    expect(request.summary).toBe('要望です\nもう一つ');
+  });
+
+  it('surface が空なら例外', () => {
+    expect(() =>
+      toCreateProductSignalRequest({ surface: '   ', summary: '要望' }),
+    ).toThrow('surface は必須です');
+  });
+
+  it(`surface が${FEEDBACK_SURFACE_MAX_LENGTH}文字を超えると例外`, () => {
+    const surface = 'a'.repeat(FEEDBACK_SURFACE_MAX_LENGTH + 1);
+    expect(() =>
+      toCreateProductSignalRequest({ surface, summary: '要望' }),
+    ).toThrow(`${FEEDBACK_SURFACE_MAX_LENGTH}文字以内`);
+  });
+
+  it(`surface が${FEEDBACK_SURFACE_MAX_LENGTH}文字ちょうどなら通る`, () => {
+    const surface = 'a'.repeat(FEEDBACK_SURFACE_MAX_LENGTH);
+    expect(
+      toCreateProductSignalRequest({ surface, summary: '要望' }).surface,
+    ).toBe(surface);
+  });
+
+  it('surface に空白が含まれると例外', () => {
+    expect(() =>
+      toCreateProductSignalRequest({ surface: 'ai chat', summary: '要望' }),
+    ).toThrow('空白・制御文字');
+  });
+
+  it('surface に制御文字が含まれると例外', () => {
+    expect(() =>
+      toCreateProductSignalRequest({
+        surface: `ai${String.fromCharCode(0)}chat`,
+        summary: '要望',
+      }),
+    ).toThrow('空白・制御文字');
+  });
+
+  it('summary が空白のみなら例外（サーバー側で500になり得るため）', () => {
+    expect(() =>
+      toCreateProductSignalRequest({ surface: 'ai.chat', summary: '   \n  ' }),
+    ).toThrow('内容を入力してください');
+  });
+
+  it('summary が制御文字のみなら例外', () => {
+    expect(() =>
+      toCreateProductSignalRequest({
+        surface: 'ai.chat',
+        summary: `${String.fromCharCode(0)}${String.fromCharCode(7)}`,
+      }),
+    ).toThrow('内容を入力してください');
+  });
+
+  it(`summary が${FEEDBACK_SUMMARY_MAX_LENGTH}文字を超えると例外`, () => {
+    const summary = 'あ'.repeat(FEEDBACK_SUMMARY_MAX_LENGTH + 1);
+    expect(() =>
+      toCreateProductSignalRequest({ surface: 'ai.chat', summary }),
+    ).toThrow(`${FEEDBACK_SUMMARY_MAX_LENGTH}文字以内`);
+  });
+
+  it(`summary が${FEEDBACK_SUMMARY_MAX_LENGTH}文字ちょうどなら通る`, () => {
+    const summary = 'あ'.repeat(FEEDBACK_SUMMARY_MAX_LENGTH);
+    expect(
+      toCreateProductSignalRequest({ surface: 'ai.chat', summary }).summary,
+    ).toBe(summary);
+  });
+
+  it('絵文字はコードポイント単位で数えるため上限ちょうどでも通る', () => {
+    const summary = '🎉'.repeat(FEEDBACK_SUMMARY_MAX_LENGTH);
+    // String.length では上限の2倍だが、ルーン数では上限ちょうど
+    expect(summary.length).toBe(FEEDBACK_SUMMARY_MAX_LENGTH * 2);
+    expect(() =>
+      toCreateProductSignalRequest({ surface: 'ai.chat', summary }),
+    ).not.toThrow();
+  });
+});
+
+describe('toProductSignal', () => {
+  it('APIレスポンスをドメイン型に変換する', () => {
+    const api: ApiProductSignal = {
+      id: 'ps_1',
+      createdAt: new Date('2026-08-04T00:00:00Z'),
+      updatedAt: new Date('2026-08-04T00:00:01Z'),
+      kind: 'explicit_request',
+      surface: 'ai.chat',
+      summary: '要約済みの内容',
+      occurredAt: new Date('2026-08-03T23:59:59Z'),
+    };
+
+    expect(toProductSignal(api)).toEqual({
+      id: 'ps_1',
+      kind: 'explicit_request',
+      surface: 'ai.chat',
+      summary: '要約済みの内容',
+      occurredAt: new Date('2026-08-03T23:59:59Z'),
+      createdAt: new Date('2026-08-04T00:00:00Z'),
+      updatedAt: new Date('2026-08-04T00:00:01Z'),
+    });
+  });
+});

--- a/packages/adapter/api/src/internal/helpers/feedback.ts
+++ b/packages/adapter/api/src/internal/helpers/feedback.ts
@@ -1,0 +1,119 @@
+import type {
+  CreateProductSignalRequest,
+  ProductSignal as ApiProductSignal,
+} from '@tsumugi-chan/client';
+import type { CreateFeedbackData, ProductSignal } from '@tsumugi/adapter';
+
+/**
+ * `surface` の最大文字数（サーバー制約）
+ */
+export const FEEDBACK_SURFACE_MAX_LENGTH = 64;
+
+/**
+ * `summary` としてサーバーが受け付ける最大文字数
+ *
+ * ただし実際に保存・返却されるのは **280文字**まで（超過分は切り詰められて失われる）。
+ * そのため入力欄の上限にこの値を使わないこと。入力側の上限は
+ * `packages/ui` の `FEEDBACK_MAX_LENGTH` が持つ。
+ */
+export const FEEDBACK_SUMMARY_MAX_LENGTH = 2000;
+
+/** 制御文字（Unicode カテゴリ Cc）。改行・タブも含む */
+const CONTROL_CHARS_GLOBAL = /\p{Cc}/gu;
+
+/** 制御文字の有無判定用（`test()` は lastIndex を持たない非グローバル版を使う） */
+const CONTROL_CHAR = /\p{Cc}/u;
+
+/** 空白文字の有無判定用 */
+const WHITESPACE = /\s/u;
+
+/**
+ * 文字数を「コードポイント数」で数える。
+ *
+ * サーバーはルーン単位で数えるため、サロゲートペア（絵文字など）を2文字として扱う
+ * `String.length` では実際より厳しく弾いてしまう。
+ */
+export function countChars(value: string): number {
+  return [...value].length;
+}
+
+/**
+ * 本文を正規化する（ピュア）
+ *
+ * - CRLF / CR を LF に統一する
+ * - 改行以外の制御文字を除去する（空白・制御文字のみの送信はサーバー側で500になり得るため）
+ * - 前後の空白を落とす
+ */
+export function normalizeFeedbackText(value: string): string {
+  return value
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((line) => line.replace(CONTROL_CHARS_GLOBAL, ''))
+    .join('\n')
+    .trim();
+}
+
+/**
+ * `surface` を正規化する（ピュア）
+ *
+ * 集計軸なので前後の空白を落とすだけに留め、内部に空白・制御文字が入っている場合は
+ * 呼び出し側のバグとして検証で弾く（黙って繋げない）。
+ */
+export function normalizeSurface(value: string): string {
+  return value.trim();
+}
+
+/**
+ * フィードバック送信データを検証し、API リクエストに変換する（ピュア）
+ *
+ * 戻り値の型を生成クライアントの {@link CreateProductSignalRequest} にすることで、
+ * `kind` / `evidence` が混入しないことを型で保証する
+ * （サーバーが whitelist 検証しているため、含めると無視ではなく 400 になる）。
+ *
+ * @throws 検証に失敗した場合（trim後の空文字・文字数超過・surface の空白/制御文字）
+ */
+export function toCreateProductSignalRequest(
+  data: CreateFeedbackData,
+): CreateProductSignalRequest {
+  const surface = normalizeSurface(data.surface);
+  const summary = normalizeFeedbackText(data.summary);
+
+  if (surface.length === 0) {
+    throw new Error('feedback: surface は必須です');
+  }
+  if (countChars(surface) > FEEDBACK_SURFACE_MAX_LENGTH) {
+    throw new Error(
+      `feedback: surface は${FEEDBACK_SURFACE_MAX_LENGTH}文字以内にしてください`,
+    );
+  }
+  if (WHITESPACE.test(surface) || CONTROL_CHAR.test(surface)) {
+    throw new Error(
+      'feedback: surface に空白・制御文字を含めることはできません',
+    );
+  }
+  if (summary.length === 0) {
+    throw new Error('feedback: 内容を入力してください');
+  }
+  if (countChars(summary) > FEEDBACK_SUMMARY_MAX_LENGTH) {
+    throw new Error(
+      `feedback: 内容は${FEEDBACK_SUMMARY_MAX_LENGTH}文字以内にしてください`,
+    );
+  }
+
+  return { surface, summary };
+}
+
+/**
+ * API レスポンスをドメイン型に変換する
+ */
+export function toProductSignal(api: ApiProductSignal): ProductSignal {
+  return {
+    id: api.id,
+    kind: api.kind,
+    surface: api.surface,
+    summary: api.summary,
+    occurredAt: api.occurredAt,
+    createdAt: api.createdAt,
+    updatedAt: api.updatedAt,
+  };
+}

--- a/packages/adapter/core/src/adapter.ts
+++ b/packages/adapter/core/src/adapter.ts
@@ -33,6 +33,8 @@ import type {
   UpdateInstructionData,
   AuthState,
   GoogleAuthUrl,
+  CreateFeedbackData,
+  ProductSignal,
 } from './types';
 
 /**
@@ -345,6 +347,21 @@ export interface ExportAdapter {
 }
 
 /**
+ * フィードバック送信のインターフェース
+ */
+export interface FeedbackAdapter {
+  /**
+   * プロダクトへの要望・不満を送信する
+   *
+   * 返り値の `summary` はサーバー側で伏字化・280文字への切り詰めが行われた結果であり、
+   * 送信した文章とは一致しない。
+   *
+   * @throws trim後の `summary` が空、または文字数制約を満たさない場合
+   */
+  send(data: CreateFeedbackData): Promise<ProductSignal>;
+}
+
+/**
  * 統合アダプター
  */
 export interface Adapter {
@@ -361,4 +378,5 @@ export interface Adapter {
   readonly glossary: GlossaryAdapter;
   readonly instructions: InstructionAdapter;
   readonly export: ExportAdapter;
+  readonly feedback: FeedbackAdapter;
 }

--- a/packages/adapter/core/src/stub.ts
+++ b/packages/adapter/core/src/stub.ts
@@ -114,5 +114,8 @@ export function createAdapter(_: AdapterConfig = {}): Adapter {
     export: {
       exportProject: () => notImplemented(),
     },
+    feedback: {
+      send: () => notImplemented(),
+    },
   };
 }

--- a/packages/adapter/core/src/types.ts
+++ b/packages/adapter/core/src/types.ts
@@ -767,4 +767,56 @@ export interface GoogleAuthUrl {
   url: string;
 }
 
+// ─── プロダクトフィードバック ───
+
+/**
+ * プロダクトシグナルの種別
+ *
+ * サーバーが判定して払い出す。フロントから送ることはできない
+ * （送信ペイロードに含めると whitelist 検証で 400 になる）。
+ */
+export type ProductSignalKind =
+  | 'explicit_request'
+  | 'friction'
+  | 'error'
+  | 'cost'
+  | 'latency';
+
+/**
+ * プロダクトへの要望・不満（サーバー保存後の姿）
+ *
+ * `summary` はサーバー側で伏字化・切り詰めが行われるため、
+ * **送信した文章とは一致しない**。UI で「送った内容」として
+ * そのまま表示しないこと。
+ */
+export interface ProductSignal extends Timestamps {
+  id: string;
+  /** シグナルの種別（サーバー判定） */
+  kind: ProductSignalKind;
+  /** どの画面・機能についてか */
+  surface: string;
+  /** 匿名化・要約済みの内容（最大280文字。作品本文は含まれない） */
+  summary: string;
+  /** シグナルが発生した日時 */
+  occurredAt: Date;
+}
+
+/**
+ * フィードバック送信データ
+ *
+ * `kind` / `evidence` は **送ってはいけない**（サーバーが whitelist 検証しており、
+ * 無視ではなく 400 になる）。そのためこの型にはフィールドを増やさないこと。
+ */
+export interface CreateFeedbackData {
+  /**
+   * どの画面・機能についてか（1〜64文字）
+   *
+   * 集計軸なのでドット区切りで命名を揃える（例: `ai.chat`, `plots.create`）。
+   * 画面側で自動付与し、ユーザーには入力させない。
+   */
+  surface: string;
+  /** 要望の本文（trim後1〜2000文字） */
+  summary: string;
+}
+
 // エクスポートは常に全コンテンツを zip-markdown で出力する（API 側にオプション未対応）。

--- a/packages/ui/src/components/features/feedback/feedback-form.stories.tsx
+++ b/packages/ui/src/components/features/feedback/feedback-form.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { FEEDBACK_MAX_LENGTH, FeedbackForm } from './feedback-form';
+
+const meta = {
+  title: 'Features/FeedbackForm',
+  component: FeedbackForm,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ height: '600px', maxWidth: '480px', padding: '24px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof FeedbackForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockSummary =
+  'プロットの並び替えをドラッグでできるようにしてほしい。今は一つずつ順番を指定しないといけないので、章が増えると大変です。';
+
+/** 代表的な入力済みの状態 */
+export const Default: Story = {
+  args: { defaultValue: mockSummary },
+};
+
+/** 未入力の状態（送信ボタンは無効） */
+export const Empty: Story = {
+  args: {},
+};
+
+/** 送信中（入力欄は編集不可になる） */
+export const Submitting: Story = {
+  args: { defaultValue: mockSummary, isSubmitting: true },
+};
+
+/** 上限超過（送信ボタンは無効・カウンタが赤・エラー文を表示） */
+export const OverLimit: Story = {
+  args: { defaultValue: 'あ'.repeat(FEEDBACK_MAX_LENGTH + 10) },
+};
+
+/** エラー表示 */
+export const WithError: Story = {
+  args: {
+    defaultValue: mockSummary,
+    error: '送信に失敗しました: ネットワークエラー',
+  },
+};
+
+/** 送信完了（サーバー側で伏字化・切り詰めされた内容が返る） */
+export const Submitted: Story = {
+  args: {
+    savedSummary:
+      'プロットの並び替えをドラッグでできるようにしてほしい。「…」という指摘もありました。',
+  },
+};
+
+/** 鉤括弧の中身が全て伏字化され、保存内容が空になったケース */
+export const SubmittedWithEmptySummary: Story = {
+  args: { savedSummary: '' },
+};
+
+/**
+ * 実際の送信フローを模したストーリー。
+ * サーバー側の伏字化（各種括弧の中身が40文字超）と280文字への切り詰めを再現する。
+ */
+export const Interactive: StoryObj = {
+  render: () => {
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [savedSummary, setSavedSummary] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    /** 括弧の中身が40文字を超えたら伏字化し、280文字に切り詰める（サーバー処理の模擬） */
+    const fakeServerProcess = (summary: string): string => {
+      const pairs: [string, string][] = [
+        ['「', '」'],
+        ['『', '』'],
+        ['“', '”'],
+      ];
+      const masked = pairs.reduce((text, [open, close]) => {
+        const pattern = new RegExp(`${open}([^${close}]*)${close}`, 'g');
+        return text.replace(pattern, (match, inner: string) =>
+          [...inner].length > 40 ? `${open}…${close}` : match,
+        );
+      }, summary);
+      return [...masked].slice(0, FEEDBACK_MAX_LENGTH).join('');
+    };
+
+    const handleSubmit = (summary: string) => {
+      setError(null);
+      setIsSubmitting(true);
+      setTimeout(() => {
+        setIsSubmitting(false);
+        setSavedSummary(fakeServerProcess(summary));
+      }, 600);
+    };
+
+    return (
+      <FeedbackForm
+        isSubmitting={isSubmitting}
+        savedSummary={savedSummary}
+        error={error}
+        onSubmit={handleSubmit}
+        onReset={() => setSavedSummary(null)}
+        onCancel={() => setSavedSummary(null)}
+      />
+    );
+  },
+};

--- a/packages/ui/src/components/features/feedback/feedback-form.tsx
+++ b/packages/ui/src/components/features/feedback/feedback-form.tsx
@@ -1,0 +1,201 @@
+import * as React from 'react';
+import { CheckCircle2Icon, SendIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { countChars, normalizeFeedbackText } from '@/lib/feedback-text';
+import { cn } from '@/lib/utils';
+
+/**
+ * 入力欄の既定の上限文字数。
+ *
+ * サーバーは2000文字まで受け付けるが、保存・返却されるのは280文字までなので、
+ * 切り詰めで内容が失われないよう入力側を280文字に寄せている。
+ */
+export const FEEDBACK_MAX_LENGTH = 280;
+
+export interface FeedbackFormProps {
+  /** 入力上限（コードポイント数）。既定は {@link FEEDBACK_MAX_LENGTH} */
+  maxLength?: number;
+  /**
+   * 入力欄の初期値。
+   *
+   * マウント時のみ参照する。閉じても下書きを保持したい場合は、
+   * 呼び出し側が {@link FeedbackFormProps.onValueChange} で受け取った値を渡し直す。
+   */
+  defaultValue?: string;
+  /** 入力が変化したときに呼ばれる（下書き保持用） */
+  onValueChange?: (value: string) => void;
+  /** 送信中かどうか */
+  isSubmitting?: boolean;
+  /**
+   * 送信完了後にサーバーが保存した内容。
+   *
+   * 伏字化・切り詰めが行われているため送信した文章とは一致しない。
+   * 値が入っている間は完了表示になる。
+   */
+  savedSummary?: string | null;
+  /** エラーメッセージ */
+  error?: string | null;
+  /** 送信（正規化済みの本文のみ。surface は呼び出し側が付与する） */
+  onSubmit?: (summary: string) => void;
+  /** 閉じる・キャンセル */
+  onCancel?: () => void;
+  /** 完了表示から入力state に戻す */
+  onReset?: () => void;
+  className?: string;
+}
+
+/**
+ * プロダクトへの要望・不満を送るフォーム。
+ *
+ * 送信内容はサーバー側で伏字化・要約されるため、その旨を明示している。
+ */
+export function FeedbackForm({
+  maxLength = FEEDBACK_MAX_LENGTH,
+  defaultValue = '',
+  onValueChange,
+  isSubmitting = false,
+  savedSummary = null,
+  error = null,
+  onSubmit,
+  onCancel,
+  onReset,
+  className,
+}: FeedbackFormProps) {
+  const [value, setValue] = React.useState(defaultValue);
+  const textareaId = React.useId();
+  const hintId = `${textareaId}-hint`;
+
+  // 送信が成功したら入力を捨てる。完了表示から戻る経路が複数あっても
+  // 送信済みのテキストが残って二重送信を誘発しないようにする。
+  const isSaved = savedSummary !== null;
+  React.useEffect(() => {
+    if (isSaved) {
+      setValue('');
+      onValueChange?.('');
+    }
+  }, [isSaved, onValueChange]);
+
+  const normalized = normalizeFeedbackText(value);
+  const length = countChars(normalized);
+  const isOverLimit = length > maxLength;
+  const submitDisabled = isSubmitting || length === 0 || isOverLimit;
+
+  const updateValue = (next: string) => {
+    setValue(next);
+    onValueChange?.(next);
+  };
+
+  const handleSubmit = () => {
+    if (submitDisabled) return;
+    onSubmit?.(normalized);
+  };
+
+  if (savedSummary !== null) {
+    return (
+      <div className={cn('space-y-4', className)}>
+        <div className="flex items-start gap-2 text-sm" role="status">
+          <CheckCircle2Icon className="mt-0.5 size-5 shrink-0 text-primary" />
+          <div className="space-y-1">
+            <p className="font-medium">送信しました。ありがとうございます。</p>
+            <p className="text-muted-foreground">
+              内容はサーバー側で要約・匿名化されて保存されました。
+            </p>
+          </div>
+        </div>
+        {savedSummary.trim().length > 0 && (
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-muted-foreground">
+              保存された内容
+            </p>
+            <p className="max-h-48 overflow-y-auto rounded-md bg-muted p-3 text-sm whitespace-pre-wrap">
+              {savedSummary}
+            </p>
+          </div>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onReset}>
+            続けて送る
+          </Button>
+          <Button type="button" onClick={onCancel}>
+            閉じる
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className={cn('space-y-4', className)}
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSubmit();
+      }}
+    >
+      <div className="space-y-1.5">
+        <label htmlFor={textareaId} className="text-sm font-medium">
+          ご意見・ご要望
+        </label>
+        <Textarea
+          id={textareaId}
+          value={value}
+          onChange={(e) => updateValue(e.target.value)}
+          disabled={isSubmitting}
+          aria-describedby={hintId}
+          aria-invalid={isOverLimit}
+          // autoResize は長文貼り付けでダイアログが画面外まで伸びてボタンに
+          // 届かなくなるため無効化し、高さを固定してスクロールさせる
+          autoResize={false}
+          className="max-h-48 min-h-32 resize-none overflow-y-auto"
+          placeholder="例：プロットの並び替えをドラッグでできるようにしてほしい"
+        />
+        <div id={hintId} className="flex items-start justify-between gap-3">
+          <p className="text-xs text-muted-foreground">
+            作品本文は貼らないでください。長い引用（「」『』“”
+            の中身が40文字超）は自動で伏字になります。
+          </p>
+          <span
+            className={cn(
+              'shrink-0 text-xs tabular-nums',
+              isOverLimit ? 'text-destructive' : 'text-muted-foreground',
+            )}
+          >
+            {length} / {maxLength}
+          </span>
+        </div>
+        {isOverLimit && (
+          <p className="text-xs text-destructive">
+            {maxLength}文字以内にしてください（現在{length}文字）。
+          </p>
+        )}
+      </div>
+
+      <p className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
+        送信された内容はサーバー側で匿名化・要約され、最大{maxLength}
+        文字で保存されます。そのため保存内容は入力した文章と一致しない場合があります。
+      </p>
+
+      {error !== null && (
+        <p
+          role="alert"
+          className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {error}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        {onCancel && (
+          <Button type="button" variant="outline" onClick={onCancel}>
+            キャンセル
+          </Button>
+        )}
+        <Button type="submit" disabled={submitDisabled}>
+          <SendIcon className="size-4" />
+          {isSubmitting ? '送信中...' : '送信'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/packages/ui/src/components/features/feedback/index.ts
+++ b/packages/ui/src/components/features/feedback/index.ts
@@ -1,0 +1,1 @@
+export * from './feedback-form';

--- a/packages/ui/src/components/features/index.ts
+++ b/packages/ui/src/components/features/index.ts
@@ -5,6 +5,7 @@ export * from './consistency-check';
 export * from './context-preview';
 export * from './edit-policy';
 export * from './editor';
+export * from './feedback';
 export * from './glossary';
 export * from './instructions';
 export * from './node-ai-attributes';

--- a/packages/ui/src/lib/feedback-text.spec.ts
+++ b/packages/ui/src/lib/feedback-text.spec.ts
@@ -1,0 +1,48 @@
+import { countChars, normalizeFeedbackText } from './feedback-text';
+
+describe('countChars', () => {
+  it('BMP内の文字はそのまま数える', () => {
+    expect(countChars('あいうえお')).toBe(5);
+  });
+
+  it('サロゲートペア（絵文字）を1文字として数える', () => {
+    expect('🎉'.length).toBe(2);
+    expect(countChars('🎉')).toBe(1);
+  });
+
+  it('空文字は0', () => {
+    expect(countChars('')).toBe(0);
+  });
+});
+
+describe('normalizeFeedbackText', () => {
+  it('前後の空白を落とす', () => {
+    expect(normalizeFeedbackText('  要望です  ')).toBe('要望です');
+  });
+
+  it('CRLF / CR を LF に統一する', () => {
+    expect(normalizeFeedbackText('1行目\r\n2行目\r3行目')).toBe(
+      '1行目\n2行目\n3行目',
+    );
+  });
+
+  it('改行は保持する', () => {
+    expect(normalizeFeedbackText('1行目\n2行目')).toBe('1行目\n2行目');
+  });
+
+  it('改行以外の制御文字を除去しつつ改行は残す', () => {
+    const input = `a${String.fromCharCode(0)}b\nc\td`;
+    expect(normalizeFeedbackText(input)).toBe('ab\ncd');
+  });
+
+  it('空白のみの入力は空文字になる', () => {
+    expect(normalizeFeedbackText('   \n\t  ')).toBe('');
+  });
+
+  it('制御文字のみの入力は空文字になる（trim では落ちないため）', () => {
+    const onlyControls = `${String.fromCharCode(0)}${String.fromCharCode(7)}`;
+    // String.trim() では落ちないことを明示
+    expect(onlyControls.trim()).not.toBe('');
+    expect(normalizeFeedbackText(onlyControls)).toBe('');
+  });
+});

--- a/packages/ui/src/lib/feedback-text.ts
+++ b/packages/ui/src/lib/feedback-text.ts
@@ -1,0 +1,30 @@
+/** 制御文字（Unicode カテゴリ Cc） */
+const CONTROL_CHARS_GLOBAL = /\p{Cc}/gu;
+
+/**
+ * フィードバック本文を正規化する。
+ *
+ * `String.trim()` は C0 制御文字を落とさないため、制御文字だけの入力を
+ * 「入力あり」と誤判定しないよう、改行以外の制御文字を除去する。
+ *
+ * 送信値をアダプター側の正規化結果と一致させる意図もある
+ * （最終的な検証は adapter-api 側が改めて行うため、ここは UI のガード）。
+ */
+export function normalizeFeedbackText(value: string): string {
+  return value
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((line) => line.replace(CONTROL_CHARS_GLOBAL, ''))
+    .join('\n')
+    .trim();
+}
+
+/**
+ * 文字数をコードポイント数で数える。
+ *
+ * サーバーはルーン単位で数えるため、サロゲートペア（絵文字など）を2文字として扱う
+ * `String.length` では実際より厳しくなってしまう。
+ */
+export function countChars(value: string): number {
+  return [...value].length;
+}


### PR DESCRIPTION
## 概要

`POST /v1/feedback` → 201 `ProductSignal` に対応し、プロダクトへの要望・不満を送れるようにした。

**`@tsumugi-chan/client` の更新は不要だった。** 1.3.1 に `FeedbackApi` / `ProductSignal` /
`CreateProductSignalRequest` が既に含まれていたため、接続するだけで済んでいる。

## レイヤーごとの変更

`.claude/rules/architecture.md` の順序（types.ts → adapter.ts → stub.ts → adapter-api → 配線 → hook → UI）に従った。

| レイヤー | 変更 |
|---|---|
| **adapter-core** | `ProductSignal` / `ProductSignalKind` / `CreateFeedbackData`、`FeedbackAdapter.send()`、stub 追加 |
| **adapter-api** | `createFeedbackAdapter`、`client.ts` に `FeedbackApi` 配線。検証・正規化は `internal/helpers/feedback.ts` にピュアロジックとして分離 |
| **packages/ui** | `FeedbackForm`（表示のみ・adapter 非依存）。正規化と文字数カウントは `lib/feedback-text.ts` に分離 |
| **apps/desktop** | `useSubmitFeedback()`、`FeedbackDialog`、ホームヘッダーの「ご意見・ご要望」ボタン |

## 仕様で特に注意した点

### `kind` / `evidence` は送らない（送ると 400）

3重に防いでいる:

1. `CreateFeedbackData` は `surface` / `summary` の2フィールドのみ
2. `toCreateProductSignalRequest()` の戻り値型を生成クライアントの `CreateProductSignalRequest` にし、
   **毎回新しいオブジェクトを組み立てて返す**（呼び出し側が余分なフィールドを持つ変数を渡しても落ちる）
3. 生成クライアントの `CreateProductSignalRequestToJSON` が最終的に whitelist する

`POST /v1/feedback` の呼び出し箇所は1つだけ。

### 入力上限は 280 文字に寄せた（推奨に従った）

サーバー受付上限は2000文字だが、保存・返却されるのは280文字までで超過分は失われる。
そのため**入力欄の上限を280文字**にし、2000文字はアダプター側の検証値として保持している。

### 保存内容が送信内容と一致しないことを明示

- フォームに「サーバー側で匿名化・要約され、最大280文字で保存されます。そのため保存内容は
  入力した文章と一致しない場合があります」と明記
- 「作品本文は貼らないでください。長い引用（`「」`『』“” の中身が40文字超）は自動で伏字になります」と警告
- 送信後は返却値を **「保存された内容」** として表示する。「送った内容」とは書いていない

### trim後の空文字を弾く

空白・制御文字のみの送信はサーバー側で500になり得るため、送信前に弾いている。

**`String.trim()` は C0 制御文字（`U+0000` 等）を落とさない**ので、trim だけでは
制御文字のみの入力を「入力あり」と誤判定する。CRLF→LF に正規化した上で、
改行以外の制御文字（`\p{Cc}`）を行単位で除去してから空判定している。
UI 側の送信ボタン活性判定も同じ正規化を通しているため、この入力でボタンが押せることはない。

### 文字数はコードポイント数で数える

サーバーはルーン単位で数えるため、サロゲートペア（絵文字）を2文字として扱う `String.length`
では実際より厳しく弾いてしまう。`[...value].length` で数えている。

### `surface` は画面側で自動付与

ユーザーには入力させない。集計軸として意味を持たせるため `FeedbackDialog` の**必須 props** にした
（ホームからは `home.feedback`）。ハードコードにすると全シグナルが1つのバケットに潰れて
集計軸として情報を持たなくなるため。

## 設置場所について

**設定画面のルートが存在しない**ため（設定的なUIは「プロジェクト設定タブ」だけ）、
アプリレベルの入口としてホーム画面ヘッダーにダイアログを置いた。
フィードバックはプロジェクトに紐づかないので、プロジェクト設定内よりこちらが妥当と判断した。

## テスト

- **`helpers/feedback.spec.ts` 25件** — 検証・正規化・変換、64/280/2000 の境界値、絵文字のコードポイント数え
  - whitelist のテストは、**余分なフィールドを持つ入力を渡して**検証している。
    実装を `{ ...data, surface, summary }` に改変すると落ちることを確認済み（キャストは使っていない）
- **`lib/feedback-text.spec.ts` 9件** — 正規化（CRLF/CR→LF、制御文字除去、改行保持）とコードポイント数え
- **Storybook 8ストーリー** — 必須の Default / Empty / Interactive に加え、Submitting / OverLimit /
  WithError / Submitted / SubmittedWithEmptySummary。Interactive は伏字化（3種の括弧）と
  280文字切り詰めを模擬している

## レビューで見つけて直した不具合

- 送信中にダイアログを閉じると、遅れて届いたレスポンスが**次回開いたときに持ち越される**バグ
  → 閉じる時ではなく**開く時**にリセット（閉じるアニメ中にフォームが一瞬見える問題も同時に解消）
- 長文を貼ると `autoResize` でダイアログが画面外まで伸び、**送信ボタンに届かなくなる**
  → `autoResize={false}` + `max-h-48 overflow-y-auto`
- 送信成功後に「閉じる」→再度開くと**送信済みテキストが残り二重送信を誘発**
  → 成功遷移時に入力をクリア
- `trigger` が後続に追い越されて `undefined` を返すケースを無視していた → エラー表示するように
- 下書きがダイアログを閉じると失われる → `FeedbackDialog` 側で保持して復元
- 固定 DOM id → `useId()`（autodocs で全ストーリーが同一ページに並ぶため label 紐付けが壊れていた）
- a11y: エラーに `role="alert"`、完了に `role="status"`、`aria-describedby` / `aria-invalid`、
  上限超過時に色以外のテキストでも通知
- 送信中は入力欄を `disabled` に

## テストプラン

CI（build / tsc / lint / test / build-storybook）はローカルで全て通ることを確認済み。

- [x] `npm run build` — 5/5 成功
- [x] `npm run tsc` — 4/4 成功
- [x] `npm run lint` — 0 errors（既存の warning 6件のみ、本PRでの増加なし）
- [x] `npm run test` — 80件成功（新規34件）
- [x] `npm run build-storybook` — 成功
- [ ] **実機確認**: ホーム → 「ご意見・ご要望」→ 送信 → 201 が返り「保存された内容」が
      表示されること（サーバー側で伏字化・280文字切り詰めされているはず）
- [ ] **実機確認**: `kind` / `evidence` が body に含まれず 400 にならないこと（DevTools の Network で確認）
- [ ] **実機確認**: 送信中にダイアログを閉じて再度開いたとき、前回の結果が残っていないこと

## 注意: ローカル環境の `node_modules` が古い

本PRとは無関係だが、共有 `node_modules` の `@tsumugi-chan/client` が **1.0.9** のままで、
`package.json` / lockfile がpinしている **1.3.1** と一致していない。
このため `npm run build` がデスクトップの prerender で
`does not provide an export named 'FindingStreamChunkFromJSON'` で失敗する
（この symbol は #39 の `consistency.ts` が使用しているもので、本PRの変更ではない）。

**`npm install` を実行すれば解消する。** CI は毎回クリーンインストールするため影響はない。
