### PR TITLE
feat: git型バージョン管理（履歴・差分・復元）をフロントに実装

### DIFF
--- a/apps/desktop/app/hooks/versions.ts
+++ b/apps/desktop/app/hooks/versions.ts
@@ -2,7 +2,6 @@ import useSWR, { type SWRConfiguration, useSWRConfig } from 'swr';
 import useSWRInfinite from 'swr/infinite';
 import useSWRMutation from 'swr/mutation';
 import type {
-  Commit,
   CommitDiff,
   CommitEntry,
   CommitList,
@@ -28,6 +27,8 @@ interface CommitsPageKey {
   projectId: string;
   /** 前ページの nextCursor。1ページ目は null */
   cursor: string | null;
+  /** 1ページあたりの件数。異なる件数でキャッシュを共有しないためキーに含める */
+  limit: number | null;
 }
 
 /**
@@ -50,32 +51,14 @@ export function useCommits(projectId: string, limit?: number) {
         type: 'commits',
         projectId,
         cursor: previous?.nextCursor ?? null,
+        limit: limit ?? null,
       };
     },
-    ({ projectId, cursor }: CommitsPageKey) =>
-      adapter.versions.listCommits(projectId, { limit, cursor }),
-  );
-}
-
-interface CommitKey {
-  type: 'commit';
-  commitId: string;
-}
-
-/**
- * コミットを1件取得する
- * @param commitId - コミットID
- * @param config
- */
-export function useCommit(
-  commitId: string,
-  config?: SWRConfiguration<Commit | null, Error>,
-) {
-  const adapter = useAdapter();
-  return useSWR<Commit | null, Error, CommitKey>(
-    { type: 'commit', commitId },
-    ({ commitId }) => adapter.versions.getCommit(commitId),
-    config,
+    ({ projectId, cursor, limit }: CommitsPageKey) =>
+      adapter.versions.listCommits(projectId, {
+        limit: limit ?? undefined,
+        cursor,
+      }),
   );
 }
 
@@ -164,6 +147,8 @@ interface NodeRevisionsPageKey {
   nodeId: string;
   /** 前ページの nextCursor。1ページ目は null */
   cursor: string | null;
+  /** 1ページあたりの件数。異なる件数でキャッシュを共有しないためキーに含める */
+  limit: number | null;
 }
 
 /**
@@ -185,31 +170,16 @@ export function useNodeRevisions(nodeId: string, limit?: number) {
         type: 'nodeRevisions',
         nodeId,
         cursor: previous?.nextCursor ?? null,
+        limit: limit ?? null,
       };
     },
-    ({ nodeId, cursor }: NodeRevisionsPageKey) =>
-      adapter.versions.listNodeRevisions(nodeId, { limit, cursor }),
+    ({ nodeId, cursor, limit }: NodeRevisionsPageKey) =>
+      adapter.versions.listNodeRevisions(nodeId, {
+        limit: limit ?? undefined,
+        cursor,
+      }),
   );
 }
-
-/**
- * 復元によって内容が書き換わる可能性のある SWR キーの種別。
- * AIセッションや使用量など、バージョン管理の対象外のキーは含めない。
- */
-const RESTORE_AFFECTED_KEY_TYPES: ReadonlySet<string> = new Set([
-  'project',
-  'projectSettings',
-  'plot',
-  'plotTree',
-  'character',
-  'characterTree',
-  'memo',
-  'memoTree',
-  'writing',
-  'writingTree',
-  'glossaryTerms',
-  'instructions',
-]);
 
 function hasStringType(key: unknown): key is { type: string } {
   return (
@@ -220,11 +190,53 @@ function hasStringType(key: unknown): key is { type: string } {
   );
 }
 
+function hasStringId(key: object): key is { id: string } {
+  return 'id' in key && typeof key.id === 'string';
+}
+
+function hasStringProjectId(key: object): key is { projectId: string } {
+  return 'projectId' in key && typeof key.projectId === 'string';
+}
+
 /**
- * 復元後に再フェッチすべきキーかどうかを判定する
+ * 復元後に再フェッチすべき SWR キーを判定する述語を作る。
+ *
+ * 無関係なプロジェクトのキャッシュまで再フェッチしないよう、
+ * プロジェクトIDを持つキーは対象プロジェクトのものだけに絞る。
+ * AIセッションや使用量など、バージョン管理の対象外のキーは含めない。
+ * `projectSettings` は localStorage 管理でサーバー状態ではないため対象外。
  */
-function isRestoreAffectedKey(key: unknown): boolean {
-  return hasStringType(key) && RESTORE_AFFECTED_KEY_TYPES.has(key.type);
+function createRestoreAffectedKeyMatcher(
+  projectId: string,
+): (key: unknown) => boolean {
+  return (key: unknown): boolean => {
+    if (!hasStringType(key)) return false;
+    switch (key.type) {
+      // プロジェクト一覧は横断的なキー。復元でプロジェクト名が変わり得るため常に対象
+      case 'projects':
+        return true;
+      // id がプロジェクトIDなので絞り込める
+      case 'project':
+        return hasStringId(key) && key.id === projectId;
+      // projectId を持つキーは対象プロジェクトのみ
+      case 'plotTree':
+      case 'characterTree':
+      case 'memoTree':
+      case 'writingTree':
+      case 'glossaryTerms':
+      case 'instructions':
+        return hasStringProjectId(key) && key.projectId === projectId;
+      // 個別ノードのキーは id がノードIDのためプロジェクトを判別できない。
+      // 開いたノードの分しかキャッシュされないので一律に対象とする
+      case 'plot':
+      case 'character':
+      case 'memo':
+      case 'writing':
+        return true;
+      default:
+        return false;
+    }
+  };
 }
 
 /**
@@ -266,12 +278,12 @@ export function useRestoreCommit(projectId: string) {
       projectId,
       baseCommitId: DEFAULT_BASE_COMMIT_ID,
     },
-    async (_, { arg: commitId }) => {
+    async ({ projectId }, { arg: commitId }) => {
       const result = await adapter.versions.restoreCommit(commitId);
       // 何も変わらなかった場合は再フェッチしない
       if (result.status === 'already_at_commit') return result;
       // 復元はプロジェクト全体を書き換えるため、影響するキーをまとめて再フェッチする
-      await mutate(isRestoreAffectedKey);
+      await mutate(createRestoreAffectedKeyMatcher(projectId));
       return result;
     },
   );
@@ -300,9 +312,9 @@ export function useRestoreNode(projectId: string) {
       projectId,
       baseCommitId: DEFAULT_BASE_COMMIT_ID,
     },
-    async (_, { arg }) => {
+    async ({ projectId }, { arg }) => {
       const node = await adapter.versions.restoreNode(arg.nodeId, arg.commitId);
-      await mutate(isRestoreAffectedKey);
+      await mutate(createRestoreAffectedKeyMatcher(projectId));
       return node;
     },
   );

--- a/apps/desktop/app/hooks/versions.ts
+++ b/apps/desktop/app/hooks/versions.ts
@@ -1,0 +1,309 @@
+import useSWR, { type SWRConfiguration, useSWRConfig } from 'swr';
+import useSWRInfinite from 'swr/infinite';
+import useSWRMutation from 'swr/mutation';
+import type {
+  Commit,
+  CommitDiff,
+  CommitEntry,
+  CommitList,
+  CreateCommitResult,
+  Node,
+  NodeRevisionList,
+  RestoreCommitResult,
+} from '@tsumugi/adapter';
+import { useAdapter } from '~/hooks/useAdapter';
+
+/**
+ * baseCommitId を省略したい場合に使うセンチネル。
+ * SWR キーには undefined を入れられないため空文字で「既定の比較元」を表す。
+ */
+const DEFAULT_BASE_COMMIT_ID = '';
+
+function toBaseCommitId(baseCommitId: string): string | undefined {
+  return baseCommitId === DEFAULT_BASE_COMMIT_ID ? undefined : baseCommitId;
+}
+
+interface CommitsPageKey {
+  type: 'commits';
+  projectId: string;
+  /** 前ページの nextCursor。1ページ目は null */
+  cursor: string | null;
+}
+
+/**
+ * プロジェクトのコミット履歴を取得する（新しい順・カーソルページネーション）。
+ *
+ * `setSize(size + 1)` で次ページを読み込む。`nextCursor === null` が終端。
+ * 自動保存コミットはバックエンドが勝手に増やすため、画面フォーカス時に
+ * 1ページ目を再取得する SWR の既定動作をそのまま利用している。
+ *
+ * @param projectId - プロジェクトID
+ * @param limit - 1ページあたりの件数（既定 50 / 最大 100）
+ */
+export function useCommits(projectId: string, limit?: number) {
+  const adapter = useAdapter();
+  return useSWRInfinite<CommitList, Error>(
+    (_index: number, previous: CommitList | null): CommitsPageKey | null => {
+      // 前ページの nextCursor が null なら終端
+      if (previous !== null && previous.nextCursor === null) return null;
+      return {
+        type: 'commits',
+        projectId,
+        cursor: previous?.nextCursor ?? null,
+      };
+    },
+    ({ projectId, cursor }: CommitsPageKey) =>
+      adapter.versions.listCommits(projectId, { limit, cursor }),
+  );
+}
+
+interface CommitKey {
+  type: 'commit';
+  commitId: string;
+}
+
+/**
+ * コミットを1件取得する
+ * @param commitId - コミットID
+ * @param config
+ */
+export function useCommit(
+  commitId: string,
+  config?: SWRConfiguration<Commit | null, Error>,
+) {
+  const adapter = useAdapter();
+  return useSWR<Commit | null, Error, CommitKey>(
+    { type: 'commit', commitId },
+    ({ commitId }) => adapter.versions.getCommit(commitId),
+    config,
+  );
+}
+
+interface CommitDiffKey {
+  type: 'commitDiff';
+  commitId: string;
+  baseCommitId: string;
+}
+
+/**
+ * コミットの差分を取得する
+ * @param commitId - 差分を見るコミットID
+ * @param baseCommitId - 比較元コミットID。空文字なら親コミットとの差分
+ * @param config
+ */
+export function useCommitDiff(
+  commitId: string,
+  baseCommitId: string = DEFAULT_BASE_COMMIT_ID,
+  config?: SWRConfiguration<CommitDiff, Error>,
+) {
+  const adapter = useAdapter();
+  return useSWR<CommitDiff, Error, CommitDiffKey>(
+    { type: 'commitDiff', commitId, baseCommitId },
+    ({ commitId, baseCommitId }) =>
+      adapter.versions.getCommitDiff(commitId, toBaseCommitId(baseCommitId)),
+    config,
+  );
+}
+
+interface ProjectDiffKey {
+  type: 'projectDiff';
+  projectId: string;
+  baseCommitId: string;
+}
+
+/**
+ * 未コミットの作業差分を取得する（返り値の commitId は常に null）
+ * @param projectId - プロジェクトID
+ * @param baseCommitId - 比較元コミットID。空文字なら最新コミットとの差分
+ * @param config
+ */
+export function useProjectDiff(
+  projectId: string,
+  baseCommitId: string = DEFAULT_BASE_COMMIT_ID,
+  config?: SWRConfiguration<CommitDiff, Error>,
+) {
+  const adapter = useAdapter();
+  return useSWR<CommitDiff, Error, ProjectDiffKey>(
+    { type: 'projectDiff', projectId, baseCommitId },
+    ({ projectId, baseCommitId }) =>
+      adapter.versions.getProjectDiff(projectId, toBaseCommitId(baseCommitId)),
+    config,
+  );
+}
+
+interface CommitEntryKey {
+  type: 'commitEntry';
+  commitId: string;
+  targetId: string;
+}
+
+/**
+ * コミット時点のエントリのスナップショットを取得する。
+ *
+ * 差分APIは `added` / `removed` の中身を返さないため、それを表示したいときに使う。
+ * @param commitId - コミットID
+ * @param targetId - 変更対象ID
+ * @param config
+ */
+export function useCommitEntry(
+  commitId: string,
+  targetId: string,
+  config?: SWRConfiguration<CommitEntry | null, Error>,
+) {
+  const adapter = useAdapter();
+  return useSWR<CommitEntry | null, Error, CommitEntryKey>(
+    { type: 'commitEntry', commitId, targetId },
+    ({ commitId, targetId }) =>
+      adapter.versions.getCommitEntry(commitId, targetId),
+    config,
+  );
+}
+
+interface NodeRevisionsPageKey {
+  type: 'nodeRevisions';
+  nodeId: string;
+  /** 前ページの nextCursor。1ページ目は null */
+  cursor: string | null;
+}
+
+/**
+ * ノードの変更履歴を取得する（新しい順・カーソルページネーション）。
+ *
+ * `setSize(size + 1)` で次ページを読み込む。`nextCursor === null` が終端。
+ * @param nodeId - ノードID
+ * @param limit - 1ページあたりの件数（既定 50 / 最大 100）
+ */
+export function useNodeRevisions(nodeId: string, limit?: number) {
+  const adapter = useAdapter();
+  return useSWRInfinite<NodeRevisionList, Error>(
+    (
+      _index: number,
+      previous: NodeRevisionList | null,
+    ): NodeRevisionsPageKey | null => {
+      if (previous !== null && previous.nextCursor === null) return null;
+      return {
+        type: 'nodeRevisions',
+        nodeId,
+        cursor: previous?.nextCursor ?? null,
+      };
+    },
+    ({ nodeId, cursor }: NodeRevisionsPageKey) =>
+      adapter.versions.listNodeRevisions(nodeId, { limit, cursor }),
+  );
+}
+
+/**
+ * 復元によって内容が書き換わる可能性のある SWR キーの種別。
+ * AIセッションや使用量など、バージョン管理の対象外のキーは含めない。
+ */
+const RESTORE_AFFECTED_KEY_TYPES: ReadonlySet<string> = new Set([
+  'project',
+  'projectSettings',
+  'plot',
+  'plotTree',
+  'character',
+  'characterTree',
+  'memo',
+  'memoTree',
+  'writing',
+  'writingTree',
+  'glossaryTerms',
+  'instructions',
+]);
+
+function hasStringType(key: unknown): key is { type: string } {
+  return (
+    typeof key === 'object' &&
+    key !== null &&
+    'type' in key &&
+    typeof key.type === 'string'
+  );
+}
+
+/**
+ * 復元後に再フェッチすべきキーかどうかを判定する
+ */
+function isRestoreAffectedKey(key: unknown): boolean {
+  return hasStringType(key) && RESTORE_AFFECTED_KEY_TYPES.has(key.type);
+}
+
+/**
+ * 手動コミット（保存）を作成する。
+ *
+ * 前回コミットから変更が無い場合は `{ status: 'no_changes' }` が返る（正常系）。
+ * エラーダイアログではなく穏当なメッセージで見せること。
+ * @param projectId - プロジェクトID
+ * @revalidates useProjectDiff - 保存すると作業差分が空になるため再フェッチする
+ */
+export function useCreateCommit(projectId: string) {
+  const adapter = useAdapter();
+  return useSWRMutation<CreateCommitResult, Error, ProjectDiffKey, string>(
+    {
+      type: 'projectDiff',
+      projectId,
+      baseCommitId: DEFAULT_BASE_COMMIT_ID,
+    },
+    ({ projectId }, { arg: message }) =>
+      adapter.versions.createCommit(projectId, message),
+  );
+}
+
+/**
+ * プロジェクト全体をコミット時点の状態に復元する（破壊的操作）。
+ *
+ * 呼び出し前に必ず確認ダイアログを出すこと。復元先に存在しないノード・執筆指示・用語は削除される。
+ * 現在の状態が復元先と完全一致している場合は `{ status: 'already_at_commit' }` が返る（正常系）。
+ * @param projectId - プロジェクトID
+ * @revalidates useProjectDiff - 作業差分が変わるため再フェッチする
+ * @revalidates useProject / usePlot / usePlotTree / useCharacter / useCharacterTree / useMemo / useMemoTree / useWriting / useWritingTree / useGlossaryTerms / useInstructions - 内容が書き換わるため再フェッチする
+ */
+export function useRestoreCommit(projectId: string) {
+  const adapter = useAdapter();
+  const { mutate } = useSWRConfig();
+  return useSWRMutation<RestoreCommitResult, Error, ProjectDiffKey, string>(
+    {
+      type: 'projectDiff',
+      projectId,
+      baseCommitId: DEFAULT_BASE_COMMIT_ID,
+    },
+    async (_, { arg: commitId }) => {
+      const result = await adapter.versions.restoreCommit(commitId);
+      // 何も変わらなかった場合は再フェッチしない
+      if (result.status === 'already_at_commit') return result;
+      // 復元はプロジェクト全体を書き換えるため、影響するキーをまとめて再フェッチする
+      await mutate(isRestoreAffectedKey);
+      return result;
+    },
+  );
+}
+
+interface RestoreNodeArg {
+  nodeId: string;
+  commitId: string;
+}
+
+/**
+ * ノードの本文をコミット時点の状態に復元する。
+ *
+ * 戻るのは本文のみで、名前・親・並び順・正典ステータス・AIコンテキスト設定は変わらない。
+ * フォルダノードに対して呼ぶとエラーになる。
+ * @param projectId - プロジェクトID
+ * @revalidates useProjectDiff - 作業差分が変わるため再フェッチする
+ * @revalidates usePlot / useCharacter / useMemo / useWriting - 本文が書き換わるため再フェッチする
+ */
+export function useRestoreNode(projectId: string) {
+  const adapter = useAdapter();
+  const { mutate } = useSWRConfig();
+  return useSWRMutation<Node, Error, ProjectDiffKey, RestoreNodeArg>(
+    {
+      type: 'projectDiff',
+      projectId,
+      baseCommitId: DEFAULT_BASE_COMMIT_ID,
+    },
+    async (_, { arg }) => {
+      const node = await adapter.versions.restoreNode(arg.nodeId, arg.commitId);
+      await mutate(isRestoreAffectedKey);
+      return node;
+    },
+  );
+}

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/character-editor-wrapper.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/character-editor-wrapper.tsx
@@ -4,9 +4,17 @@ import {
   useCharacterTree,
   useUpdateCharacter,
 } from '~/hooks/characters';
-import { CharacterEditor, type CharacterEditorData } from '@tsumugi/ui';
+import {
+  CharacterEditor,
+  type CharacterEditorData,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from '@tsumugi/ui';
 import { useDebouncedSave } from '~/routes/(private)/workspace/[projectId]/_hooks/useDebouncedSave';
 import { NodeAttributesBar } from './node-attributes-bar';
+import { NodeRevisionWrapper } from '../version-history/node-revision-wrapper';
 import type { Character } from '@tsumugi/adapter';
 
 const NO_REVALIDATE = {
@@ -64,7 +72,7 @@ export function CharacterEditorWrapper({
   if (!character) return null;
 
   return (
-    <div className="flex h-full flex-col">
+    <Tabs defaultValue="body" className="flex h-full min-h-0 flex-col gap-0">
       <NodeAttributesBar
         projectId={projectId}
         contentType="character"
@@ -72,13 +80,21 @@ export function CharacterEditorWrapper({
         canonStatus={character.canonStatus}
         contextPolicy={character.contextPolicy}
         editPolicy={character.editPolicy}
-      />
-      <div className="min-h-0 flex-1">
+      >
+        <TabsList className="h-7">
+          <TabsTrigger value="body">内容</TabsTrigger>
+          <TabsTrigger value="history">履歴</TabsTrigger>
+        </TabsList>
+      </NodeAttributesBar>
+      <TabsContent value="body" className="min-h-0 flex-1">
         <CharacterEditor
           data={toEditorData(character)}
           onChange={handleChange}
         />
-      </div>
-    </div>
+      </TabsContent>
+      <TabsContent value="history" className="min-h-0 flex-1">
+        <NodeRevisionWrapper projectId={projectId} nodeId={id} />
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/memo-editor-wrapper.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/memo-editor-wrapper.tsx
@@ -4,9 +4,16 @@ import {
   useMemoTree,
   useUpdateMemo,
 } from '~/hooks/memos';
-import { MemoEditor } from '@tsumugi/ui';
+import {
+  MemoEditor,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from '@tsumugi/ui';
 import { useDebouncedSave } from '~/routes/(private)/workspace/[projectId]/_hooks/useDebouncedSave';
 import { NodeAttributesBar } from './node-attributes-bar';
+import { NodeRevisionWrapper } from '../version-history/node-revision-wrapper';
 
 const NO_REVALIDATE = {
   revalidateOnFocus: false,
@@ -46,7 +53,7 @@ export function MemoEditorWrapper({ id, projectId }: MemoEditorWrapperProps) {
   if (!memo) return null;
 
   return (
-    <div className="flex h-full flex-col">
+    <Tabs defaultValue="body" className="flex h-full min-h-0 flex-col gap-0">
       <NodeAttributesBar
         projectId={projectId}
         contentType="memo"
@@ -54,8 +61,13 @@ export function MemoEditorWrapper({ id, projectId }: MemoEditorWrapperProps) {
         canonStatus={memo.canonStatus}
         contextPolicy={memo.contextPolicy}
         editPolicy={memo.editPolicy}
-      />
-      <div className="min-h-0 flex-1">
+      >
+        <TabsList className="h-7">
+          <TabsTrigger value="body">内容</TabsTrigger>
+          <TabsTrigger value="history">履歴</TabsTrigger>
+        </TabsList>
+      </NodeAttributesBar>
+      <TabsContent value="body" className="min-h-0 flex-1">
         <MemoEditor
           name={memo.name}
           content={memo.content}
@@ -64,7 +76,10 @@ export function MemoEditorWrapper({ id, projectId }: MemoEditorWrapperProps) {
           onContentChange={(v) => handleFieldChange('content', v)}
           onTagsChange={(v) => handleFieldChange('tags', v)}
         />
-      </div>
-    </div>
+      </TabsContent>
+      <TabsContent value="history" className="min-h-0 flex-1">
+        <NodeRevisionWrapper projectId={projectId} nodeId={id} />
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/plot-editor-wrapper.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/plot-editor-wrapper.tsx
@@ -1,8 +1,16 @@
 import { useCallback } from 'react';
 import { usePlot, usePlotTree, useUpdatePlot } from '~/hooks/plots';
-import { PlotEditor, type PlotEditorData } from '@tsumugi/ui';
+import {
+  PlotEditor,
+  type PlotEditorData,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from '@tsumugi/ui';
 import { useDebouncedSave } from '~/routes/(private)/workspace/[projectId]/_hooks/useDebouncedSave';
 import { NodeAttributesBar } from './node-attributes-bar';
+import { NodeRevisionWrapper } from '../version-history/node-revision-wrapper';
 import type { Plot } from '@tsumugi/adapter';
 
 const NO_REVALIDATE = {
@@ -54,7 +62,7 @@ export function PlotEditorWrapper({ id, projectId }: PlotEditorWrapperProps) {
   if (!plot) return null;
 
   return (
-    <div className="flex h-full flex-col">
+    <Tabs defaultValue="body" className="flex h-full min-h-0 flex-col gap-0">
       <NodeAttributesBar
         projectId={projectId}
         contentType="plot"
@@ -62,10 +70,18 @@ export function PlotEditorWrapper({ id, projectId }: PlotEditorWrapperProps) {
         canonStatus={plot.canonStatus}
         contextPolicy={plot.contextPolicy}
         editPolicy={plot.editPolicy}
-      />
-      <div className="min-h-0 flex-1">
+      >
+        <TabsList className="h-7">
+          <TabsTrigger value="body">内容</TabsTrigger>
+          <TabsTrigger value="history">履歴</TabsTrigger>
+        </TabsList>
+      </NodeAttributesBar>
+      <TabsContent value="body" className="min-h-0 flex-1">
         <PlotEditor data={toEditorData(plot)} onChange={handleChange} />
-      </div>
-    </div>
+      </TabsContent>
+      <TabsContent value="history" className="min-h-0 flex-1">
+        <NodeRevisionWrapper projectId={projectId} nodeId={id} />
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/project-editor-wrapper.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/project-editor-wrapper.tsx
@@ -12,6 +12,7 @@ import {
 import { useDebouncedSave } from '~/routes/(private)/workspace/[projectId]/_hooks/useDebouncedSave';
 import { GlossaryManagerWrapper } from '../glossary-manager-wrapper';
 import { InstructionsManagerWrapper } from '../instructions-manager-wrapper';
+import { VersionHistoryWrapper } from '../version-history/version-history-wrapper';
 import type { Project } from '@tsumugi/adapter';
 
 const NO_REVALIDATE = {
@@ -81,6 +82,7 @@ export function ProjectEditorWrapper({
         <TabsTrigger value="basic">基本情報</TabsTrigger>
         <TabsTrigger value="glossary">用語集</TabsTrigger>
         <TabsTrigger value="instructions">執筆指示</TabsTrigger>
+        <TabsTrigger value="history">変更履歴</TabsTrigger>
       </TabsList>
       <TabsContent value="basic" className="min-h-0 flex-1">
         <ProjectEditor
@@ -95,6 +97,9 @@ export function ProjectEditorWrapper({
       </TabsContent>
       <TabsContent value="instructions" className="min-h-0 flex-1">
         <InstructionsManagerWrapper projectId={projectId} />
+      </TabsContent>
+      <TabsContent value="history" className="min-h-0 flex-1">
+        <VersionHistoryWrapper projectId={projectId} />
       </TabsContent>
     </Tabs>
   );

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/writing-editor-wrapper.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/editors/writing-editor-wrapper.tsx
@@ -10,6 +10,7 @@ import {
 import { useDebouncedSave } from '~/routes/(private)/workspace/[projectId]/_hooks/useDebouncedSave';
 import { NodeAttributesBar } from './node-attributes-bar';
 import { ConsistencyPanelWrapper } from '../consistency-panel-wrapper';
+import { NodeRevisionWrapper } from '../version-history/node-revision-wrapper';
 
 const NO_REVALIDATE = {
   revalidateOnFocus: false,
@@ -81,6 +82,7 @@ export function WritingEditorWrapper({
         <TabsList className="h-7">
           <TabsTrigger value="body">本文</TabsTrigger>
           <TabsTrigger value="consistency">整合性チェック</TabsTrigger>
+          <TabsTrigger value="history">履歴</TabsTrigger>
         </TabsList>
       </NodeAttributesBar>
       <TabsContent value="body" className="min-h-0 flex-1">
@@ -93,6 +95,9 @@ export function WritingEditorWrapper({
       </TabsContent>
       <TabsContent value="consistency" className="min-h-0 flex-1">
         <ConsistencyPanelWrapper writingId={id} projectId={projectId} />
+      </TabsContent>
+      <TabsContent value="history" className="min-h-0 flex-1">
+        <NodeRevisionWrapper projectId={projectId} nodeId={id} />
       </TabsContent>
     </Tabs>
   );

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/commit-diff-loader.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/commit-diff-loader.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CommitDiffView, type CommitEntryContentItem } from '@tsumugi/ui';
+import { useCommitDiff, useCommitEntry } from '~/hooks/versions';
+import {
+  EMPTY_ENTRY_CONTENT,
+  toDiffEntryItem,
+  toEntryContentItem,
+} from './converters';
+
+type EntryContentMap = Record<string, CommitEntryContentItem | undefined>;
+
+interface EntryContentLoaderProps {
+  commitId: string;
+  targetId: string;
+  onLoaded: (targetId: string, content: CommitEntryContentItem) => void;
+}
+
+/**
+ * コミット時点のエントリ内容を1件ロードして親に引き上げる。
+ * targetId が確定してからマウントされる（条件付きレンダリング）。
+ */
+function EntryContentLoader({
+  commitId,
+  targetId,
+  onLoaded,
+}: EntryContentLoaderProps) {
+  const { data, error } = useCommitEntry(commitId, targetId);
+
+  useEffect(() => {
+    // 取得できなかった場合も空の内容を返し、読み込み中のまま止めない
+    if (data !== undefined) {
+      onLoaded(
+        targetId,
+        data === null ? EMPTY_ENTRY_CONTENT : toEntryContentItem(data),
+      );
+    } else if (error !== undefined) {
+      onLoaded(targetId, EMPTY_ENTRY_CONTENT);
+    }
+  }, [data, error, targetId, onLoaded]);
+
+  return null;
+}
+
+interface CommitDiffLoaderProps {
+  commitId: string;
+  title: string;
+  subtitle?: string | null;
+  /** 指定するとそのエントリの差分だけを表示する（ノード単位の履歴用） */
+  targetId?: string;
+  emptyMessage?: string;
+}
+
+/**
+ * コミットの差分を取得して表示する。
+ *
+ * 差分APIは `added` / `removed` の中身を返さないため、
+ * ユーザーが「中身を表示」を押したときだけ `getCommitEntry` を追加で叩く。
+ */
+export function CommitDiffLoader({
+  commitId,
+  title,
+  subtitle,
+  targetId,
+  emptyMessage,
+}: CommitDiffLoaderProps) {
+  const { data, isLoading } = useCommitDiff(commitId);
+  const [requestedIds, setRequestedIds] = useState<string[]>([]);
+  const [contents, setContents] = useState<EntryContentMap>({});
+
+  // 別のコミットを選び直したら取得済みの内容は捨てる
+  useEffect(() => {
+    setRequestedIds([]);
+    setContents({});
+  }, [commitId]);
+
+  const handleLoaded = useCallback(
+    (loadedTargetId: string, content: CommitEntryContentItem) => {
+      setContents((prev) =>
+        prev[loadedTargetId] === content
+          ? prev
+          : { ...prev, [loadedTargetId]: content },
+      );
+    },
+    [],
+  );
+
+  const entries = useMemo(() => {
+    const all = data?.entries ?? [];
+    const filtered =
+      targetId === undefined
+        ? all
+        : all.filter((entry) => entry.targetId === targetId);
+    return filtered.map(toDiffEntryItem);
+  }, [data, targetId]);
+
+  const loadingEntryIds = useMemo(
+    () => requestedIds.filter((id) => contents[id] === undefined),
+    [requestedIds, contents],
+  );
+
+  const handleShowEntryContent = useCallback((id: string) => {
+    setRequestedIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+  }, []);
+
+  return (
+    <>
+      {requestedIds.map((id) => (
+        <EntryContentLoader
+          key={id}
+          commitId={commitId}
+          targetId={id}
+          onLoaded={handleLoaded}
+        />
+      ))}
+      <CommitDiffView
+        entries={entries}
+        title={title}
+        subtitle={subtitle}
+        isLoading={isLoading}
+        entryContents={contents}
+        loadingEntryIds={loadingEntryIds}
+        onShowEntryContent={handleShowEntryContent}
+        emptyMessage={emptyMessage}
+      />
+    </>
+  );
+}

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/commit-diff-loader.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/commit-diff-loader.tsx
@@ -13,6 +13,7 @@ interface EntryContentLoaderProps {
   commitId: string;
   targetId: string;
   onLoaded: (targetId: string, content: CommitEntryContentItem) => void;
+  onFailed: (targetId: string) => void;
 }
 
 /**
@@ -23,20 +24,24 @@ function EntryContentLoader({
   commitId,
   targetId,
   onLoaded,
+  onFailed,
 }: EntryContentLoaderProps) {
   const { data, error } = useCommitEntry(commitId, targetId);
 
   useEffect(() => {
-    // 取得できなかった場合も空の内容を返し、読み込み中のまま止めない
     if (data !== undefined) {
+      // 404（null）は「中身が無い」ので空の内容として確定させる
       onLoaded(
         targetId,
         data === null ? EMPTY_ENTRY_CONTENT : toEntryContentItem(data),
       );
-    } else if (error !== undefined) {
-      onLoaded(targetId, EMPTY_ENTRY_CONTENT);
+      return;
     }
-  }, [data, error, targetId, onLoaded]);
+    if (error !== undefined) {
+      // 通信エラーは確定させない。要求を取り下げて再試行できる状態に戻す
+      onFailed(targetId);
+    }
+  }, [data, error, targetId, onLoaded, onFailed]);
 
   return null;
 }
@@ -63,7 +68,7 @@ export function CommitDiffLoader({
   targetId,
   emptyMessage,
 }: CommitDiffLoaderProps) {
-  const { data, isLoading } = useCommitDiff(commitId);
+  const { data, error, isLoading, mutate } = useCommitDiff(commitId);
   const [requestedIds, setRequestedIds] = useState<string[]>([]);
   const [contents, setContents] = useState<EntryContentMap>({});
 
@@ -75,14 +80,16 @@ export function CommitDiffLoader({
 
   const handleLoaded = useCallback(
     (loadedTargetId: string, content: CommitEntryContentItem) => {
-      setContents((prev) =>
-        prev[loadedTargetId] === content
-          ? prev
-          : { ...prev, [loadedTargetId]: content },
-      );
+      setContents((prev) => ({ ...prev, [loadedTargetId]: content }));
     },
     [],
   );
+
+  // 取得に失敗したら要求を取り下げ、「中身を表示」ボタンを復活させる。
+  // ローダーがアンマウントされるので、押し直せば SWR が再取得する。
+  const handleFailed = useCallback((failedTargetId: string) => {
+    setRequestedIds((prev) => prev.filter((id) => id !== failedTargetId));
+  }, []);
 
   const entries = useMemo(() => {
     const all = data?.entries ?? [];
@@ -110,6 +117,7 @@ export function CommitDiffLoader({
           commitId={commitId}
           targetId={id}
           onLoaded={handleLoaded}
+          onFailed={handleFailed}
         />
       ))}
       <CommitDiffView
@@ -121,6 +129,8 @@ export function CommitDiffLoader({
         loadingEntryIds={loadingEntryIds}
         onShowEntryContent={handleShowEntryContent}
         emptyMessage={emptyMessage}
+        hasError={error !== undefined}
+        onRetry={() => void mutate()}
       />
     </>
   );

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/converters.ts
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/converters.ts
@@ -1,0 +1,75 @@
+import type {
+  Commit,
+  CommitDiffEntry,
+  CommitEntry,
+  NodeRevision,
+} from '@tsumugi/adapter';
+import type {
+  CommitDiffEntryItem,
+  CommitEntryContentItem,
+  CommitTimelineItem,
+  NodeRevisionItem,
+} from '@tsumugi/ui';
+
+export function toTimelineItem(commit: Commit): CommitTimelineItem {
+  return {
+    id: commit.id,
+    message: commit.message,
+    commitType: commit.commitType,
+    addedCount: commit.addedCount,
+    modifiedCount: commit.modifiedCount,
+    removedCount: commit.removedCount,
+    createdAt: commit.createdAt,
+  };
+}
+
+export function toDiffEntryItem(entry: CommitDiffEntry): CommitDiffEntryItem {
+  return {
+    entryType: entry.entryType,
+    targetId: entry.targetId,
+    changeType: entry.changeType,
+    name: entry.name,
+    nodeType: entry.nodeType,
+    fieldChanges: entry.fieldChanges.map((change) => ({
+      field: change.field,
+      oldValue: change.oldValue,
+      newValue: change.newValue,
+    })),
+    textDiffs: entry.textDiffs.map((textDiff) => ({
+      field: textDiff.field,
+      lines: textDiff.lines.map((line) => ({ op: line.op, text: line.text })),
+    })),
+  };
+}
+
+export function toEntryContentItem(entry: CommitEntry): CommitEntryContentItem {
+  return {
+    metaFields: entry.metaFields.map((field) => ({
+      field: field.field,
+      value: field.value,
+    })),
+    contentFields: entry.contentFields.map((field) => ({
+      field: field.field,
+      value: field.value,
+    })),
+  };
+}
+
+export function toNodeRevisionItem(revision: NodeRevision): NodeRevisionItem {
+  return {
+    commitId: revision.commitId,
+    message: revision.message,
+    commitType: revision.commitType,
+    createdAt: revision.createdAt,
+    changeType: revision.changeType,
+  };
+}
+
+/**
+ * エントリ内容が取得できなかった場合に使う空の内容。
+ * 「読み込み中」のまま止まらないようにするためのプレースホルダ。
+ */
+export const EMPTY_ENTRY_CONTENT: CommitEntryContentItem = {
+  metaFields: [],
+  contentFields: [],
+};

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/node-revision-wrapper.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/node-revision-wrapper.tsx
@@ -21,6 +21,7 @@ export function NodeRevisionWrapper({
 }: NodeRevisionWrapperProps) {
   const {
     data: pages,
+    error: revisionsError,
     isLoading,
     isValidating,
     size,
@@ -49,6 +50,7 @@ export function NodeRevisionWrapper({
     pages[pages.length - 1].nextCursor !== null;
   const isLoadingMore =
     isValidating && pages !== undefined && size > pages.length;
+  const isRefreshing = !isLoading && isValidating;
 
   const handleRestore = useCallback(
     (commitId: string) => {
@@ -61,13 +63,15 @@ export function NodeRevisionWrapper({
           setNotice(
             `「${target?.message ?? ''}」の時点の本文に戻しました。名前や置き場所は変わっていません。`,
           );
+          // 復元による変更が履歴に載る場合に取り逃さないよう再取得する
+          await mutateRevisions();
         } catch (e: unknown) {
           console.error('[versions] restoreNode failed:', e);
           setNotice('本文の復元に失敗しました。もう一度お試しください。');
         }
       })();
     },
-    [restoreNode, nodeId, revisions],
+    [restoreNode, nodeId, revisions, mutateRevisions],
   );
 
   const selected = revisions.find(
@@ -80,6 +84,8 @@ export function NodeRevisionWrapper({
       selectedCommitId={selectedCommitId}
       isLoading={isLoading}
       isLoadingMore={isLoadingMore}
+      isRefreshing={isRefreshing}
+      hasError={revisionsError !== undefined}
       hasMore={hasMore}
       isRestoring={isRestoring}
       notice={notice}

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/node-revision-wrapper.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/node-revision-wrapper.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useMemo, useState } from 'react';
+import { CommitDiffView, NodeRevisionPanel } from '@tsumugi/ui';
+import { useNodeRevisions, useRestoreNode } from '~/hooks/versions';
+import { CommitDiffLoader } from './commit-diff-loader';
+import { toNodeRevisionItem } from './converters';
+
+interface NodeRevisionWrapperProps {
+  projectId: string;
+  /** 履歴を表示するノードID（フォルダノードでは使えない） */
+  nodeId: string;
+}
+
+/**
+ * ノード単位の変更履歴パネルと差分ビューをつなぐラッパー。
+ *
+ * 復元は本文のみが対象で、名前・置き場所・並び順・AI属性は変わらない。
+ */
+export function NodeRevisionWrapper({
+  projectId,
+  nodeId,
+}: NodeRevisionWrapperProps) {
+  const {
+    data: pages,
+    isLoading,
+    isValidating,
+    size,
+    setSize,
+    mutate: mutateRevisions,
+  } = useNodeRevisions(nodeId);
+  const { trigger: restoreNode, isMutating: isRestoring } =
+    useRestoreNode(projectId);
+
+  const [selectedCommitId, setSelectedCommitId] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const revisions = useMemo(
+    () => (pages ?? []).flatMap((page) => page.revisions),
+    [pages],
+  );
+  const revisionItems = useMemo(
+    () => revisions.map(toNodeRevisionItem),
+    [revisions],
+  );
+
+  // next_cursor === null が終端（has_more は存在しない）
+  const hasMore =
+    pages !== undefined &&
+    pages.length > 0 &&
+    pages[pages.length - 1].nextCursor !== null;
+  const isLoadingMore =
+    isValidating && pages !== undefined && size > pages.length;
+
+  const handleRestore = useCallback(
+    (commitId: string) => {
+      void (async () => {
+        try {
+          await restoreNode({ nodeId, commitId });
+          const target = revisions.find(
+            (revision) => revision.commitId === commitId,
+          );
+          setNotice(
+            `「${target?.message ?? ''}」の時点の本文に戻しました。名前や置き場所は変わっていません。`,
+          );
+        } catch (e: unknown) {
+          console.error('[versions] restoreNode failed:', e);
+          setNotice('本文の復元に失敗しました。もう一度お試しください。');
+        }
+      })();
+    },
+    [restoreNode, nodeId, revisions],
+  );
+
+  const selected = revisions.find(
+    (revision) => revision.commitId === selectedCommitId,
+  );
+
+  return (
+    <NodeRevisionPanel
+      revisions={revisionItems}
+      selectedCommitId={selectedCommitId}
+      isLoading={isLoading}
+      isLoadingMore={isLoadingMore}
+      hasMore={hasMore}
+      isRestoring={isRestoring}
+      notice={notice}
+      onDismissNotice={() => setNotice(null)}
+      onSelect={setSelectedCommitId}
+      onRestore={handleRestore}
+      onLoadMore={() => void setSize(size + 1)}
+      onRefresh={() => void mutateRevisions()}
+      detail={
+        selectedCommitId !== null ? (
+          <CommitDiffLoader
+            commitId={selectedCommitId}
+            title={selected?.message ?? 'このコミットの差分'}
+            subtitle="このノードの差分"
+            targetId={nodeId}
+            emptyMessage="このコミットでは、このノードの本文に差分がありません。"
+          />
+        ) : (
+          <CommitDiffView
+            entries={[]}
+            emptyMessage="履歴を選ぶと、その時点の差分が表示されます。"
+          />
+        )
+      }
+    />
+  );
+}

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/version-history-wrapper.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/version-history-wrapper.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useMemo, useState } from 'react';
+import { CommitDiffView, CommitTimeline } from '@tsumugi/ui';
+import {
+  useCommits,
+  useCreateCommit,
+  useProjectDiff,
+  useRestoreCommit,
+} from '~/hooks/versions';
+import { CommitDiffLoader } from './commit-diff-loader';
+import { toDiffEntryItem, toTimelineItem } from './converters';
+
+/** 履歴パネルで選択中の対象 */
+type Selection =
+  | { kind: 'uncommitted' }
+  | { kind: 'commit'; commitId: string }
+  | null;
+
+interface VersionHistoryWrapperProps {
+  projectId: string;
+}
+
+/**
+ * プロジェクトの変更履歴タイムラインと差分ビューをつなぐラッパー。
+ *
+ * 「変更がない」「既にこの状態」はバックエンドが正常系として返すため、
+ * エラー扱いにせず穏当な通知として表示する。
+ */
+export function VersionHistoryWrapper({
+  projectId,
+}: VersionHistoryWrapperProps) {
+  const {
+    data: pages,
+    isLoading,
+    isValidating,
+    size,
+    setSize,
+    mutate: mutateCommits,
+  } = useCommits(projectId);
+  const { data: projectDiff, mutate: mutateProjectDiff } =
+    useProjectDiff(projectId);
+  const { trigger: createCommit, isMutating: isSaving } =
+    useCreateCommit(projectId);
+  const { trigger: restoreCommit, isMutating: isRestoring } =
+    useRestoreCommit(projectId);
+
+  const [selection, setSelection] = useState<Selection>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [undoBackupCommitId, setUndoBackupCommitId] = useState<string | null>(
+    null,
+  );
+
+  const commits = useMemo(
+    () => (pages ?? []).flatMap((page) => page.commits),
+    [pages],
+  );
+  const timelineItems = useMemo(
+    () => commits.map(toTimelineItem),
+    [commits],
+  );
+
+  // next_cursor === null が終端（has_more は存在しない）
+  const hasMore =
+    pages !== undefined &&
+    pages.length > 0 &&
+    pages[pages.length - 1].nextCursor !== null;
+  const isLoadingMore =
+    isValidating && pages !== undefined && size > pages.length;
+
+  const uncommittedEntries = useMemo(
+    () => (projectDiff?.entries ?? []).map(toDiffEntryItem),
+    [projectDiff],
+  );
+  const hasUncommittedChanges = uncommittedEntries.length > 0;
+
+  const refresh = useCallback(async () => {
+    await Promise.all([mutateCommits(), mutateProjectDiff()]);
+  }, [mutateCommits, mutateProjectDiff]);
+
+  const handleSave = useCallback(
+    (message: string) => {
+      void (async () => {
+        try {
+          const result = await createCommit(message);
+          if (result === undefined) return;
+          if (result.status === 'no_changes') {
+            setNotice('変更はありません。');
+            return;
+          }
+          setNotice(null);
+          setUndoBackupCommitId(null);
+          setSelection({ kind: 'commit', commitId: result.commit.id });
+          await mutateCommits();
+        } catch (e: unknown) {
+          console.error('[versions] createCommit failed:', e);
+          setNotice('保存に失敗しました。もう一度お試しください。');
+        }
+      })();
+    },
+    [createCommit, mutateCommits],
+  );
+
+  const handleRestore = useCallback(
+    (commitId: string) => {
+      void (async () => {
+        try {
+          const result = await restoreCommit(commitId);
+          if (result === undefined) return;
+          if (result.status === 'already_at_commit') {
+            setNotice('既にこの状態です。');
+            return;
+          }
+          setNotice(null);
+          // 復元前の状態はバックアップコミットに退避される（未コミット変更が無ければ null）
+          setUndoBackupCommitId(result.result.backupCommitId);
+          setSelection({
+            kind: 'commit',
+            commitId: result.result.restoreCommitId,
+          });
+          await mutateCommits();
+        } catch (e: unknown) {
+          console.error('[versions] restoreCommit failed:', e);
+          setNotice('復元に失敗しました。もう一度お試しください。');
+        }
+      })();
+    },
+    [restoreCommit, mutateCommits],
+  );
+
+  const selectedCommit =
+    selection?.kind === 'commit'
+      ? commits.find((commit) => commit.id === selection.commitId)
+      : undefined;
+
+  const detail = (() => {
+    if (selection === null) {
+      return (
+        <CommitDiffView
+          entries={[]}
+          emptyMessage="履歴を選ぶと、その時点の差分が表示されます。"
+        />
+      );
+    }
+    if (selection.kind === 'uncommitted') {
+      return (
+        <CommitDiffView
+          entries={uncommittedEntries}
+          title="未コミットの変更"
+          subtitle="最新コミットとの差分"
+          emptyMessage="未コミットの変更はありません。"
+        />
+      );
+    }
+    return (
+      <CommitDiffLoader
+        commitId={selection.commitId}
+        title={selectedCommit?.message ?? 'このコミットの差分'}
+        subtitle="親コミットとの差分"
+      />
+    );
+  })();
+
+  return (
+    <CommitTimeline
+      commits={timelineItems}
+      hasUncommittedChanges={hasUncommittedChanges}
+      selectedCommitId={
+        selection?.kind === 'commit' ? selection.commitId : null
+      }
+      isUncommittedSelected={selection?.kind === 'uncommitted'}
+      isLoading={isLoading}
+      isLoadingMore={isLoadingMore}
+      hasMore={hasMore}
+      isSaving={isSaving}
+      isRestoring={isRestoring}
+      notice={notice}
+      onDismissNotice={() => setNotice(null)}
+      undoBackupCommitId={undoBackupCommitId}
+      onUndoRestore={handleRestore}
+      onDismissUndo={() => setUndoBackupCommitId(null)}
+      onSave={handleSave}
+      onSelectCommit={(commitId) => setSelection({ kind: 'commit', commitId })}
+      onSelectUncommitted={() => setSelection({ kind: 'uncommitted' })}
+      onRestore={handleRestore}
+      onLoadMore={() => void setSize(size + 1)}
+      onRefresh={() => void refresh()}
+      detail={detail}
+    />
+  );
+}

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/version-history-wrapper.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/version-history/version-history-wrapper.tsx
@@ -30,14 +30,19 @@ export function VersionHistoryWrapper({
 }: VersionHistoryWrapperProps) {
   const {
     data: pages,
+    error: commitsError,
     isLoading,
     isValidating,
     size,
     setSize,
     mutate: mutateCommits,
   } = useCommits(projectId);
-  const { data: projectDiff, mutate: mutateProjectDiff } =
-    useProjectDiff(projectId);
+  const {
+    data: projectDiff,
+    error: projectDiffError,
+    isValidating: isValidatingProjectDiff,
+    mutate: mutateProjectDiff,
+  } = useProjectDiff(projectId);
   const { trigger: createCommit, isMutating: isSaving } =
     useCreateCommit(projectId);
   const { trigger: restoreCommit, isMutating: isRestoring } =
@@ -53,10 +58,7 @@ export function VersionHistoryWrapper({
     () => (pages ?? []).flatMap((page) => page.commits),
     [pages],
   );
-  const timelineItems = useMemo(
-    () => commits.map(toTimelineItem),
-    [commits],
-  );
+  const timelineItems = useMemo(() => commits.map(toTimelineItem), [commits]);
 
   // next_cursor === null が終端（has_more は存在しない）
   const hasMore =
@@ -65,12 +67,17 @@ export function VersionHistoryWrapper({
     pages[pages.length - 1].nextCursor !== null;
   const isLoadingMore =
     isValidating && pages !== undefined && size > pages.length;
+  // 初回読み込み後の再検証（再取得ボタン / フォーカス復帰）
+  const isRefreshing = !isLoading && (isValidating || isValidatingProjectDiff);
 
   const uncommittedEntries = useMemo(
     () => (projectDiff?.entries ?? []).map(toDiffEntryItem),
     [projectDiff],
   );
-  const hasUncommittedChanges = uncommittedEntries.length > 0;
+  // 取得に失敗したときも行を残す。隠すと「未保存の編集が無い」と誤解させるため、
+  // クリックしてエラーと再試行を見せられるようにする。
+  const hasUncommittedChanges =
+    uncommittedEntries.length > 0 || projectDiffError !== undefined;
 
   const refresh = useCallback(async () => {
     await Promise.all([mutateCommits(), mutateProjectDiff()]);
@@ -147,6 +154,8 @@ export function VersionHistoryWrapper({
           title="未コミットの変更"
           subtitle="最新コミットとの差分"
           emptyMessage="未コミットの変更はありません。"
+          hasError={projectDiffError !== undefined}
+          onRetry={() => void mutateProjectDiff()}
         />
       );
     }
@@ -169,6 +178,8 @@ export function VersionHistoryWrapper({
       isUncommittedSelected={selection?.kind === 'uncommitted'}
       isLoading={isLoading}
       isLoadingMore={isLoadingMore}
+      isRefreshing={isRefreshing}
+      hasError={commitsError !== undefined}
       hasMore={hasMore}
       isSaving={isSaving}
       isRestoring={isRestoring}

--- a/packages/adapter/api/src/adapter.ts
+++ b/packages/adapter/api/src/adapter.ts
@@ -12,6 +12,7 @@ import { createAIAdapter } from '@/adapters/ai';
 import { createConsistencyAdapter } from '@/adapters/consistency';
 import { createGlossaryAdapter } from '@/adapters/glossary';
 import { createInstructionAdapter } from '@/adapters/instruction';
+import { createVersionAdapter } from '@/adapters/version';
 import { createExportAdapter } from '@/adapters/export';
 import { TokenManager } from '@/token-manager';
 
@@ -42,6 +43,7 @@ export function createAdapter(config: AdapterConfig = {}): Adapter {
     consistency: createConsistencyAdapter(clients),
     glossary: createGlossaryAdapter(clients),
     instructions: createInstructionAdapter(clients),
+    versions: createVersionAdapter(clients),
     export: createExportAdapter(clients),
   };
 }

--- a/packages/adapter/api/src/adapters/node.ts
+++ b/packages/adapter/api/src/adapters/node.ts
@@ -1,22 +1,6 @@
 import type { Node, NodeAdapter, NodeAttributes } from '@tsumugi/adapter';
 import type { ApiClients } from '@/client';
-import type { Node as ApiNode } from '@tsumugi-chan/client';
-
-function toNode(api: ApiNode): Node {
-  return {
-    id: api.id,
-    projectId: api.projectId,
-    parentId: api.parentId,
-    name: api.name,
-    nodeType: api.nodeType,
-    order: api.order,
-    canonStatus: api.canonStatus,
-    contextPolicy: api.contextPolicy,
-    editPolicy: api.editPolicy,
-    createdAt: api.createdAt,
-    updatedAt: api.updatedAt,
-  };
-}
+import { toNode } from '@/internal/helpers/node';
 
 export function createNodeAdapter(clients: ApiClients): NodeAdapter {
   return {

--- a/packages/adapter/api/src/adapters/version.ts
+++ b/packages/adapter/api/src/adapters/version.ts
@@ -1,0 +1,140 @@
+import type {
+  Commit,
+  CommitDiff,
+  CommitEntry,
+  CommitList,
+  CreateCommitResult,
+  Node,
+  NodeRevisionList,
+  PaginationParams,
+  RestoreCommitResult,
+  VersionAdapter,
+} from '@tsumugi/adapter';
+import type { ApiClients } from '@/client';
+import {
+  toOptionalQueryValue,
+  toPaginationQuery,
+} from '@/internal/helpers/query';
+import {
+  isConflictError,
+  isNotFoundError,
+} from '@/internal/helpers/response-error';
+import {
+  toCommit,
+  toCommitDiff,
+  toCommitEntry,
+  toCommitList,
+  toNodeRevisionList,
+  toRestoreResult,
+} from '@/internal/helpers/version';
+import { toNode } from '@/internal/helpers/node';
+
+export function createVersionAdapter(clients: ApiClients): VersionAdapter {
+  return {
+    async createCommit(
+      projectId: string,
+      message: string,
+    ): Promise<CreateCommitResult> {
+      try {
+        const commit = await clients.projects.createCommit({
+          projectId,
+          createCommitRequest: { message },
+        });
+        return { status: 'created', commit: toCommit(commit) };
+      } catch (e: unknown) {
+        // 409 は「前回コミットから変更がない」という正常系
+        if (isConflictError(e)) return { status: 'no_changes' };
+        throw e;
+      }
+    },
+
+    async listCommits(
+      projectId: string,
+      params?: PaginationParams,
+    ): Promise<CommitList> {
+      const list = await clients.projects.getCommits({
+        projectId,
+        ...toPaginationQuery(params),
+      });
+      return toCommitList(list);
+    },
+
+    async getCommit(commitId: string): Promise<Commit | null> {
+      try {
+        const commit = await clients.commits.getCommit({ commitId });
+        return toCommit(commit);
+      } catch (e: unknown) {
+        if (isNotFoundError(e)) return null;
+        throw e;
+      }
+    },
+
+    async getCommitDiff(
+      commitId: string,
+      baseCommitId?: string,
+    ): Promise<CommitDiff> {
+      const diff = await clients.commits.getCommitDiff({
+        commitId,
+        baseCommitId: toOptionalQueryValue(baseCommitId),
+      });
+      return toCommitDiff(diff);
+    },
+
+    async getProjectDiff(
+      projectId: string,
+      baseCommitId?: string,
+    ): Promise<CommitDiff> {
+      const diff = await clients.projects.getProjectDiff({
+        projectId,
+        baseCommitId: toOptionalQueryValue(baseCommitId),
+      });
+      return toCommitDiff(diff);
+    },
+
+    async getCommitEntry(
+      commitId: string,
+      targetId: string,
+    ): Promise<CommitEntry | null> {
+      try {
+        const entry = await clients.commits.getCommitEntry({
+          commitId,
+          targetId,
+        });
+        return toCommitEntry(entry);
+      } catch (e: unknown) {
+        if (isNotFoundError(e)) return null;
+        throw e;
+      }
+    },
+
+    async restoreCommit(commitId: string): Promise<RestoreCommitResult> {
+      try {
+        const result = await clients.commits.restoreCommit({ commitId });
+        return { status: 'restored', result: toRestoreResult(result) };
+      } catch (e: unknown) {
+        // 409 は「現在の状態が復元先と完全一致」という正常系
+        if (isConflictError(e)) return { status: 'already_at_commit' };
+        throw e;
+      }
+    },
+
+    async listNodeRevisions(
+      nodeId: string,
+      params?: PaginationParams,
+    ): Promise<NodeRevisionList> {
+      const list = await clients.nodes.getNodeRevisions({
+        nodeId,
+        ...toPaginationQuery(params),
+      });
+      return toNodeRevisionList(list);
+    },
+
+    async restoreNode(nodeId: string, commitId: string): Promise<Node> {
+      const node = await clients.nodes.restoreNode({
+        nodeId,
+        restoreNodeRequest: { commitId },
+      });
+      return toNode(node);
+    },
+  };
+}

--- a/packages/adapter/api/src/client.spec.ts
+++ b/packages/adapter/api/src/client.spec.ts
@@ -1,0 +1,134 @@
+import { createApiClients } from '@/client';
+import { TokenManager } from '@/token-manager';
+
+/** exp が十分先の、リフレッシュ不要なダミー JWT */
+function dummyJwt(): string {
+  const payload = Buffer.from(JSON.stringify({ exp: 9999999999 })).toString(
+    'base64url',
+  );
+  return `header.${payload}.signature`;
+}
+
+/**
+ * 検証対象は URL だけなので、レスポンスは
+ * CommitList / CommitDiff / NodeRevisionList すべてを満たす上位集合を返す。
+ */
+const RESPONSE_BODY = JSON.stringify({
+  commits: [],
+  revisions: [],
+  entries: [],
+  base_commit_id: null,
+  commit_id: null,
+  next_cursor: null,
+});
+
+type FetchMock = (input: RequestInfo | URL) => Promise<Response>;
+
+/** モック関数を global.fetch に代入できる型に変換する */
+function toFetch(mock: FetchMock): typeof fetch {
+  return mock as unknown as typeof fetch;
+}
+
+function setup() {
+  const calls: string[] = [];
+  const fetchMock = jest.fn((input: RequestInfo | URL) => {
+    calls.push(String(input));
+    return Promise.resolve(
+      new Response(RESPONSE_BODY, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  });
+  global.fetch = toFetch(fetchMock);
+
+  const tokenManager = new TokenManager();
+  tokenManager.setToken(dummyJwt());
+  const clients = createApiClients('https://api.example.com', tokenManager);
+  return { clients, calls };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('createApiClients の空クエリ除去ミドルウェア', () => {
+  it('limit / cursor が空文字なら、クエリを付けずにリクエストする', async () => {
+    const { clients, calls } = setup();
+
+    await clients.projects.getCommits({
+      projectId: 'project_1',
+      limit: '',
+      cursor: '',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe(
+      'https://api.example.com/v1/projects/project_1/commits',
+    );
+  });
+
+  it('limit のみ指定なら limit だけを送る', async () => {
+    const { clients, calls } = setup();
+
+    await clients.projects.getCommits({
+      projectId: 'project_1',
+      limit: '20',
+      cursor: '',
+    });
+
+    expect(calls[0]).toBe(
+      'https://api.example.com/v1/projects/project_1/commits?limit=20',
+    );
+  });
+
+  it('cursor が指定されていれば残す', async () => {
+    const { clients, calls } = setup();
+
+    await clients.projects.getCommits({
+      projectId: 'project_1',
+      limit: '20',
+      cursor: 'cursor_2',
+    });
+
+    expect(calls[0]).toBe(
+      'https://api.example.com/v1/projects/project_1/commits?limit=20&cursor=cursor_2',
+    );
+  });
+
+  it('base_commit_id が空文字なら送らない（コミット差分）', async () => {
+    const { clients, calls } = setup();
+
+    await clients.commits.getCommitDiff({
+      commitId: 'commit_1',
+      baseCommitId: '',
+    });
+
+    expect(calls[0]).toBe('https://api.example.com/v1/commits/commit_1/diff');
+  });
+
+  it('base_commit_id が指定されていれば送る（作業差分）', async () => {
+    const { clients, calls } = setup();
+
+    await clients.projects.getProjectDiff({
+      projectId: 'project_1',
+      baseCommitId: 'commit_1',
+    });
+
+    expect(calls[0]).toBe(
+      'https://api.example.com/v1/projects/project_1/diff?base_commit_id=commit_1',
+    );
+  });
+
+  it('ノードの変更履歴でも空クエリを除去する', async () => {
+    const { clients, calls } = setup();
+
+    await clients.nodes.getNodeRevisions({
+      nodeId: 'node_1',
+      limit: '',
+      cursor: '',
+    });
+
+    expect(calls[0]).toBe('https://api.example.com/v1/nodes/node_1/revisions');
+  });
+});

--- a/packages/adapter/api/src/client.ts
+++ b/packages/adapter/api/src/client.ts
@@ -8,16 +8,19 @@ import {
   AiApi,
   AuthApi,
   NodesApi,
+  CommitsApi,
   ConsistencyApi,
   GlossaryApi,
   InstructionsApi,
 } from '@tsumugi-chan/client';
 import type { TokenManager } from '@/token-manager';
+import { stripEmptyQueryParams } from '@/internal/helpers/query';
 
 export interface ApiClients {
   readonly auth: AuthApi;
   readonly projects: ProjectsApi;
   readonly nodes: NodesApi;
+  readonly commits: CommitsApi;
   readonly plots: PlotsApi;
   readonly characters: CharactersApi;
   readonly memos: MemosApi;
@@ -36,11 +39,21 @@ export function createApiClients(
   const configuration = new Configuration({
     basePath: baseUrl,
     accessToken: () => tokenManager.getAccessToken(),
+    middleware: [
+      {
+        // 生成クライアントが必須扱いしている省略可能なクエリパラメータ
+        // （limit / cursor / base_commit_id）は、省略を空文字で表現して
+        // ここで実際のリクエストから落とす。詳細は stripEmptyQueryParams を参照。
+        pre: ({ url, init }) =>
+          Promise.resolve({ url: stripEmptyQueryParams(url), init }),
+      },
+    ],
   });
   return {
     auth: new AuthApi(configuration),
     projects: new ProjectsApi(configuration),
     nodes: new NodesApi(configuration),
+    commits: new CommitsApi(configuration),
     plots: new PlotsApi(configuration),
     characters: new CharactersApi(configuration),
     memos: new MemosApi(configuration),

--- a/packages/adapter/api/src/internal/helpers/node.ts
+++ b/packages/adapter/api/src/internal/helpers/node.ts
@@ -1,0 +1,21 @@
+import type { Node } from '@tsumugi/adapter';
+import type { Node as ApiNode } from '@tsumugi-chan/client';
+
+/**
+ * 生成クライアントの Node を adapter-core の Node に変換する。
+ */
+export function toNode(api: ApiNode): Node {
+  return {
+    id: api.id,
+    projectId: api.projectId,
+    parentId: api.parentId,
+    name: api.name,
+    nodeType: api.nodeType,
+    order: api.order,
+    canonStatus: api.canonStatus,
+    contextPolicy: api.contextPolicy,
+    editPolicy: api.editPolicy,
+    createdAt: api.createdAt,
+    updatedAt: api.updatedAt,
+  };
+}

--- a/packages/adapter/api/src/internal/helpers/query.spec.ts
+++ b/packages/adapter/api/src/internal/helpers/query.spec.ts
@@ -1,0 +1,108 @@
+import {
+  stripEmptyQueryParams,
+  toOptionalQueryValue,
+  toPaginationQuery,
+} from '@/internal/helpers/query';
+
+describe('stripEmptyQueryParams', () => {
+  it('クエリが無い URL はそのまま返す', () => {
+    expect(stripEmptyQueryParams('https://api.example.com/v1/commits')).toBe(
+      'https://api.example.com/v1/commits',
+    );
+  });
+
+  it('値が空文字のパラメータを取り除く', () => {
+    expect(stripEmptyQueryParams('https://x/v1/commits?limit=50&cursor=')).toBe(
+      'https://x/v1/commits?limit=50',
+    );
+  });
+
+  it('全てのパラメータが空文字なら ? ごと取り除く', () => {
+    expect(stripEmptyQueryParams('https://x/v1/commits?limit=&cursor=')).toBe(
+      'https://x/v1/commits',
+    );
+  });
+
+  it('値を持つパラメータは順序を保って残す', () => {
+    expect(
+      stripEmptyQueryParams('https://x/v1/diff?a=1&base_commit_id=&b=2'),
+    ).toBe('https://x/v1/diff?a=1&b=2');
+  });
+
+  it('値なしパラメータ（= を含まない）は残す', () => {
+    expect(stripEmptyQueryParams('https://x/v1/commits?flag&cursor=')).toBe(
+      'https://x/v1/commits?flag',
+    );
+  });
+
+  it('値に = を含むパラメータは残す', () => {
+    expect(stripEmptyQueryParams('https://x/v1/commits?cursor=abc%3D')).toBe(
+      'https://x/v1/commits?cursor=abc%3D',
+    );
+    expect(stripEmptyQueryParams('https://x/v1/commits?cursor=a=b')).toBe(
+      'https://x/v1/commits?cursor=a=b',
+    );
+  });
+
+  it('フラグメントを保持する', () => {
+    expect(stripEmptyQueryParams('https://x/p?limit=10&cursor=#frag')).toBe(
+      'https://x/p?limit=10#frag',
+    );
+    expect(stripEmptyQueryParams('https://x/p?limit=&cursor=#frag')).toBe(
+      'https://x/p#frag',
+    );
+  });
+
+  it('空のクエリ（? のみ）を取り除く', () => {
+    expect(stripEmptyQueryParams('https://x/v1/commits?')).toBe(
+      'https://x/v1/commits',
+    );
+  });
+});
+
+describe('toOptionalQueryValue', () => {
+  it('undefined / null は空文字に変換する', () => {
+    expect(toOptionalQueryValue(undefined)).toBe('');
+    expect(toOptionalQueryValue(null)).toBe('');
+  });
+
+  it('値はそのまま返す', () => {
+    expect(toOptionalQueryValue('commit_1')).toBe('commit_1');
+  });
+});
+
+describe('toPaginationQuery', () => {
+  it('未指定なら limit / cursor ともに空文字（バックエンドの既定値に任せる）', () => {
+    expect(toPaginationQuery()).toEqual({ limit: '', cursor: '' });
+    expect(toPaginationQuery({})).toEqual({ limit: '', cursor: '' });
+  });
+
+  it('limit / cursor を文字列に変換する', () => {
+    expect(toPaginationQuery({ limit: 20, cursor: 'c1' })).toEqual({
+      limit: '20',
+      cursor: 'c1',
+    });
+  });
+
+  it('limit を 1〜100 にクランプする', () => {
+    expect(toPaginationQuery({ limit: 0 }).limit).toBe('1');
+    expect(toPaginationQuery({ limit: -10 }).limit).toBe('1');
+    expect(toPaginationQuery({ limit: 100 }).limit).toBe('100');
+    expect(toPaginationQuery({ limit: 1000 }).limit).toBe('100');
+  });
+
+  it('小数の limit は整数に丸める', () => {
+    expect(toPaginationQuery({ limit: 25.9 }).limit).toBe('25');
+  });
+
+  it('NaN / Infinity の limit は未指定として扱う', () => {
+    expect(toPaginationQuery({ limit: Number.NaN }).limit).toBe('');
+    expect(toPaginationQuery({ limit: Number.POSITIVE_INFINITY }).limit).toBe(
+      '',
+    );
+  });
+
+  it('cursor が null なら空文字にする', () => {
+    expect(toPaginationQuery({ cursor: null }).cursor).toBe('');
+  });
+});

--- a/packages/adapter/api/src/internal/helpers/query.ts
+++ b/packages/adapter/api/src/internal/helpers/query.ts
@@ -1,0 +1,75 @@
+import type { PaginationParams } from '@tsumugi/adapter';
+
+/** limit の下限 */
+const MIN_PAGE_LIMIT = 1;
+/** limit の上限（バックエンド仕様） */
+const MAX_PAGE_LIMIT = 100;
+
+/**
+ * URL から「値が空文字のクエリパラメータ」を取り除く。
+ *
+ * 生成クライアントは `limit` / `cursor` / `base_commit_id` といった
+ * 本来は省略可能なクエリパラメータを必須（`string`）として型付けしている。
+ * そのため省略を表現できず、`RequiredError` を避けるには空文字を渡すしかない。
+ * 空文字をそのまま送ると `?cursor=` のような無意味なクエリになりバックエンドで
+ * 不正なカーソルとして扱われるため、リクエスト直前にここで落とす。
+ *
+ * 値を持たないパラメータ（`?flag`）は空文字ではないため残す。
+ */
+export function stripEmptyQueryParams(url: string): string {
+  const queryStart = url.indexOf('?');
+  if (queryStart === -1) return url;
+
+  const base = url.slice(0, queryStart);
+  const rest = url.slice(queryStart + 1);
+  const hashStart = rest.indexOf('#');
+  const rawQuery = hashStart === -1 ? rest : rest.slice(0, hashStart);
+  const hash = hashStart === -1 ? '' : rest.slice(hashStart);
+
+  const kept = rawQuery.split('&').filter((part) => {
+    if (part.length === 0) return false;
+    const eq = part.indexOf('=');
+    // `?flag` のような値なしパラメータは空文字ではないので残す
+    if (eq === -1) return true;
+    return part.slice(eq + 1).length > 0;
+  });
+
+  if (kept.length === 0) return `${base}${hash}`;
+  return `${base}?${kept.join('&')}${hash}`;
+}
+
+/**
+ * 省略可能な文字列クエリパラメータを、生成クライアントが要求する `string` に変換する。
+ *
+ * 未指定は空文字で表現し、実際のリクエストからは
+ * {@link stripEmptyQueryParams} が取り除く。
+ */
+export function toOptionalQueryValue(value: string | null | undefined): string {
+  return value ?? '';
+}
+
+/**
+ * ページネーションパラメータを、生成クライアントが要求する形（必須の string）に変換する。
+ *
+ * - `limit` 未指定時は空文字を返し、バックエンドのデフォルト（50）に任せる
+ * - `limit` 指定時は整数に丸めた上で 1〜100 にクランプする
+ * - `cursor` 未指定時は空文字を返す
+ */
+export function toPaginationQuery(params: PaginationParams = {}): {
+  limit: string;
+  cursor: string;
+} {
+  return {
+    limit: toLimitQueryValue(params.limit),
+    cursor: toOptionalQueryValue(params.cursor),
+  };
+}
+
+function toLimitQueryValue(limit: number | undefined): string {
+  if (limit === undefined || !Number.isFinite(limit)) return '';
+  const clamped = Math.min(
+    MAX_PAGE_LIMIT,
+    Math.max(MIN_PAGE_LIMIT, Math.trunc(limit)),
+  );
+  return String(clamped);
+}

--- a/packages/adapter/api/src/internal/helpers/response-error.spec.ts
+++ b/packages/adapter/api/src/internal/helpers/response-error.spec.ts
@@ -1,0 +1,46 @@
+import { FetchError, RequiredError, ResponseError } from '@tsumugi-chan/client';
+import {
+  isConflictError,
+  isNotFoundError,
+  isResponseErrorWithStatus,
+} from '@/internal/helpers/response-error';
+
+function responseError(status: number): ResponseError {
+  return new ResponseError(new Response(null, { status }));
+}
+
+describe('isResponseErrorWithStatus', () => {
+  it('ステータスが一致する ResponseError を検出する', () => {
+    expect(isResponseErrorWithStatus(responseError(409), 409)).toBe(true);
+  });
+
+  it('ステータスが一致しない場合は false', () => {
+    expect(isResponseErrorWithStatus(responseError(500), 409)).toBe(false);
+  });
+
+  it('ResponseError 以外は false', () => {
+    expect(
+      isResponseErrorWithStatus(new FetchError(new Error('offline')), 409),
+    ).toBe(false);
+    expect(isResponseErrorWithStatus(new RequiredError('cursor'), 409)).toBe(
+      false,
+    );
+    expect(isResponseErrorWithStatus(new Error('boom'), 409)).toBe(false);
+    expect(isResponseErrorWithStatus(undefined, 409)).toBe(false);
+    expect(isResponseErrorWithStatus('409', 409)).toBe(false);
+  });
+});
+
+describe('isNotFoundError', () => {
+  it('404 のみ true', () => {
+    expect(isNotFoundError(responseError(404))).toBe(true);
+    expect(isNotFoundError(responseError(409))).toBe(false);
+  });
+});
+
+describe('isConflictError', () => {
+  it('409 のみ true', () => {
+    expect(isConflictError(responseError(409))).toBe(true);
+    expect(isConflictError(responseError(404))).toBe(false);
+  });
+});

--- a/packages/adapter/api/src/internal/helpers/response-error.ts
+++ b/packages/adapter/api/src/internal/helpers/response-error.ts
@@ -1,0 +1,31 @@
+import { ResponseError } from '@tsumugi-chan/client';
+
+/**
+ * 生成クライアントが投げたエラーが、指定した HTTP ステータスのレスポンスエラーかどうかを判定する。
+ *
+ * ネットワークエラー（`FetchError`）やパラメータ不足（`RequiredError`）を
+ * 誤って握り潰さないために、`catch` では必ずこの判定を通すこと。
+ */
+export function isResponseErrorWithStatus(
+  error: unknown,
+  status: number,
+): boolean {
+  return error instanceof ResponseError && error.response.status === status;
+}
+
+/**
+ * 404 Not Found かどうか（`getXxx()` が null を返すべきケース）
+ */
+export function isNotFoundError(error: unknown): boolean {
+  return isResponseErrorWithStatus(error, 404);
+}
+
+/**
+ * 409 Conflict かどうか
+ *
+ * バージョン管理では 409 が正常系として返る箇所があるため、
+ * 呼び出し側で専用のドメインエラーに変換する。
+ */
+export function isConflictError(error: unknown): boolean {
+  return isResponseErrorWithStatus(error, 409);
+}

--- a/packages/adapter/api/src/internal/helpers/version.spec.ts
+++ b/packages/adapter/api/src/internal/helpers/version.spec.ts
@@ -1,0 +1,277 @@
+import {
+  CommitDiffFromJSON,
+  CommitEntryFromJSON,
+  CommitFromJSON,
+  CommitListFromJSON,
+  NodeRevisionListFromJSON,
+  RestoreResultFromJSON,
+} from '@tsumugi-chan/client';
+import {
+  toCommit,
+  toCommitDiff,
+  toCommitEntry,
+  toCommitList,
+  toNodeRevisionList,
+  toRestoreResult,
+} from '@/internal/helpers/version';
+
+const commitJson = {
+  id: 'commit_1',
+  created_at: '2026-08-04T12:34:56Z',
+  project_id: 'project_1',
+  parent_id: null,
+  message: '第一章を書き上げた',
+  commit_type: 'manual',
+  added_count: 2,
+  modified_count: 1,
+  removed_count: 0,
+};
+
+describe('toCommit', () => {
+  it('コミットを変換する（createdAt は Date）', () => {
+    const commit = toCommit(CommitFromJSON(commitJson));
+    expect(commit).toEqual({
+      id: 'commit_1',
+      projectId: 'project_1',
+      parentId: null,
+      message: '第一章を書き上げた',
+      commitType: 'manual',
+      addedCount: 2,
+      modifiedCount: 1,
+      removedCount: 0,
+      createdAt: new Date('2026-08-04T12:34:56Z'),
+    });
+    expect(commit.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('parent_id が入っていれば保持する', () => {
+    const commit = toCommit(
+      CommitFromJSON({ ...commitJson, parent_id: 'commit_0' }),
+    );
+    expect(commit.parentId).toBe('commit_0');
+  });
+});
+
+describe('toCommitList', () => {
+  it('next_cursor が null なら終端として変換する', () => {
+    const list = toCommitList(
+      CommitListFromJSON({ commits: [commitJson], next_cursor: null }),
+    );
+    expect(list.commits).toHaveLength(1);
+    expect(list.commits[0].id).toBe('commit_1');
+    expect(list.nextCursor).toBeNull();
+  });
+
+  it('next_cursor があれば保持する', () => {
+    const list = toCommitList(
+      CommitListFromJSON({ commits: [], next_cursor: 'cursor_2' }),
+    );
+    expect(list.commits).toEqual([]);
+    expect(list.nextCursor).toBe('cursor_2');
+  });
+});
+
+describe('toCommitDiff', () => {
+  it('modified エントリの field_changes / text_diffs を変換する', () => {
+    const diff = toCommitDiff(
+      CommitDiffFromJSON({
+        base_commit_id: 'commit_0',
+        commit_id: 'commit_1',
+        entries: [
+          {
+            entry_type: 'node',
+            target_id: 'node_1',
+            change_type: 'modified',
+            name: '第一章',
+            node_type: 'writing',
+            field_changes: [
+              { field: 'name', old_value: '序章', new_value: '第一章' },
+              { field: 'tags', old_value: null, new_value: '伏線' },
+            ],
+            text_diffs: [
+              {
+                field: 'content',
+                lines: [
+                  { op: 'eq', text: '雨が降っていた。' },
+                  { op: 'del', text: '彼は歩いた。' },
+                  { op: 'add', text: '彼は走った。' },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(diff.baseCommitId).toBe('commit_0');
+    expect(diff.commitId).toBe('commit_1');
+    expect(diff.entries[0]).toEqual({
+      entryType: 'node',
+      targetId: 'node_1',
+      changeType: 'modified',
+      name: '第一章',
+      nodeType: 'writing',
+      fieldChanges: [
+        { field: 'name', oldValue: '序章', newValue: '第一章' },
+        { field: 'tags', oldValue: null, newValue: '伏線' },
+      ],
+      textDiffs: [
+        {
+          field: 'content',
+          lines: [
+            { op: 'eq', text: '雨が降っていた。' },
+            { op: 'del', text: '彼は歩いた。' },
+            { op: 'add', text: '彼は走った。' },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('added / removed エントリは field_changes / text_diffs が空配列になる', () => {
+    const diff = toCommitDiff(
+      CommitDiffFromJSON({
+        base_commit_id: null,
+        commit_id: 'commit_1',
+        entries: [
+          {
+            entry_type: 'node',
+            target_id: 'node_new',
+            change_type: 'added',
+            name: '新しいメモ',
+            node_type: 'memo',
+            field_changes: [],
+            text_diffs: [],
+          },
+          {
+            entry_type: 'glossary_term',
+            target_id: 'term_1',
+            change_type: 'removed',
+            name: '古い用語',
+            node_type: null,
+            field_changes: [],
+            text_diffs: [],
+          },
+        ],
+      }),
+    );
+
+    expect(diff.baseCommitId).toBeNull();
+    expect(diff.entries[0].fieldChanges).toEqual([]);
+    expect(diff.entries[0].textDiffs).toEqual([]);
+    expect(diff.entries[1].entryType).toBe('glossary_term');
+    expect(diff.entries[1].nodeType).toBeNull();
+  });
+
+  it('未コミットの作業差分は commit_id が null になる', () => {
+    const diff = toCommitDiff(
+      CommitDiffFromJSON({
+        base_commit_id: 'commit_1',
+        commit_id: null,
+        entries: [],
+      }),
+    );
+    expect(diff.commitId).toBeNull();
+    expect(diff.entries).toEqual([]);
+  });
+});
+
+describe('toCommitEntry', () => {
+  it('meta_fields / content_fields を変換する', () => {
+    const entry = toCommitEntry(
+      CommitEntryFromJSON({
+        entry_type: 'node',
+        target_id: 'node_1',
+        name: '第一章',
+        node_type: 'writing',
+        meta_fields: [{ field: 'canon_status', value: 'confirmed' }],
+        content_fields: [
+          { field: 'content', value: '雨が降っていた。' },
+          { field: 'notes', value: null },
+        ],
+      }),
+    );
+    expect(entry).toEqual({
+      entryType: 'node',
+      targetId: 'node_1',
+      name: '第一章',
+      nodeType: 'writing',
+      metaFields: [{ field: 'canon_status', value: 'confirmed' }],
+      contentFields: [
+        { field: 'content', value: '雨が降っていた。' },
+        { field: 'notes', value: null },
+      ],
+    });
+  });
+});
+
+describe('toNodeRevisionList', () => {
+  it('ノード変更履歴を変換する', () => {
+    const list = toNodeRevisionList(
+      NodeRevisionListFromJSON({
+        revisions: [
+          {
+            commit_id: 'commit_2',
+            message: '自動保存',
+            commit_type: 'auto',
+            created_at: '2026-08-04T09:00:00Z',
+            change_type: 'modified',
+          },
+          {
+            commit_id: 'commit_1',
+            message: '初稿',
+            commit_type: 'manual',
+            created_at: '2026-08-03T09:00:00Z',
+            change_type: 'added',
+          },
+        ],
+        next_cursor: null,
+      }),
+    );
+
+    expect(list.nextCursor).toBeNull();
+    expect(list.revisions).toEqual([
+      {
+        commitId: 'commit_2',
+        message: '自動保存',
+        commitType: 'auto',
+        createdAt: new Date('2026-08-04T09:00:00Z'),
+        changeType: 'modified',
+      },
+      {
+        commitId: 'commit_1',
+        message: '初稿',
+        commitType: 'manual',
+        createdAt: new Date('2026-08-03T09:00:00Z'),
+        changeType: 'added',
+      },
+    ]);
+  });
+});
+
+describe('toRestoreResult', () => {
+  it('バックアップコミットIDを保持する', () => {
+    expect(
+      toRestoreResult(
+        RestoreResultFromJSON({
+          backup_commit_id: 'commit_backup',
+          restore_commit_id: 'commit_restore',
+        }),
+      ),
+    ).toEqual({
+      backupCommitId: 'commit_backup',
+      restoreCommitId: 'commit_restore',
+    });
+  });
+
+  it('未コミット変更が無い場合は backup_commit_id が null', () => {
+    expect(
+      toRestoreResult(
+        RestoreResultFromJSON({
+          backup_commit_id: null,
+          restore_commit_id: 'commit_restore',
+        }),
+      ).backupCommitId,
+    ).toBeNull();
+  });
+});

--- a/packages/adapter/api/src/internal/helpers/version.ts
+++ b/packages/adapter/api/src/internal/helpers/version.ts
@@ -1,0 +1,135 @@
+import type {
+  Commit,
+  CommitDiff,
+  CommitDiffEntry,
+  CommitEntry,
+  CommitEntryField,
+  CommitList,
+  DiffFieldChange,
+  DiffLine,
+  NodeRevision,
+  NodeRevisionList,
+  RestoreResult,
+  TextDiff,
+} from '@tsumugi/adapter';
+import type {
+  Commit as ApiCommit,
+  CommitDiff as ApiCommitDiff,
+  CommitDiffEntry as ApiCommitDiffEntry,
+  CommitEntry as ApiCommitEntry,
+  CommitEntryField as ApiCommitEntryField,
+  CommitList as ApiCommitList,
+  DiffLine as ApiDiffLine,
+  FieldChange as ApiFieldChange,
+  NodeRevision as ApiNodeRevision,
+  NodeRevisionList as ApiNodeRevisionList,
+  RestoreResult as ApiRestoreResult,
+  TextDiff as ApiTextDiff,
+} from '@tsumugi-chan/client';
+
+export function toCommit(api: ApiCommit): Commit {
+  return {
+    id: api.id,
+    projectId: api.projectId,
+    parentId: api.parentId,
+    message: api.message,
+    commitType: api.commitType,
+    addedCount: api.addedCount,
+    modifiedCount: api.modifiedCount,
+    removedCount: api.removedCount,
+    createdAt: api.createdAt,
+  };
+}
+
+export function toCommitList(api: ApiCommitList): CommitList {
+  return {
+    commits: api.commits.map(toCommit),
+    nextCursor: api.nextCursor,
+  };
+}
+
+export function toDiffFieldChange(api: ApiFieldChange): DiffFieldChange {
+  return {
+    field: api.field,
+    oldValue: api.oldValue,
+    newValue: api.newValue,
+  };
+}
+
+export function toDiffLine(api: ApiDiffLine): DiffLine {
+  return {
+    op: api.op,
+    text: api.text,
+  };
+}
+
+export function toTextDiff(api: ApiTextDiff): TextDiff {
+  return {
+    field: api.field,
+    lines: api.lines.map(toDiffLine),
+  };
+}
+
+export function toCommitDiffEntry(api: ApiCommitDiffEntry): CommitDiffEntry {
+  return {
+    entryType: api.entryType,
+    targetId: api.targetId,
+    changeType: api.changeType,
+    name: api.name,
+    nodeType: api.nodeType,
+    // added / removed では必ず空配列が返る（バックエンド仕様）
+    fieldChanges: api.fieldChanges.map(toDiffFieldChange),
+    textDiffs: api.textDiffs.map(toTextDiff),
+  };
+}
+
+export function toCommitDiff(api: ApiCommitDiff): CommitDiff {
+  return {
+    baseCommitId: api.baseCommitId,
+    // 未コミットの作業差分（getProjectDiff）では常に null
+    commitId: api.commitId,
+    entries: api.entries.map(toCommitDiffEntry),
+  };
+}
+
+export function toCommitEntryField(api: ApiCommitEntryField): CommitEntryField {
+  return {
+    field: api.field,
+    value: api.value,
+  };
+}
+
+export function toCommitEntry(api: ApiCommitEntry): CommitEntry {
+  return {
+    entryType: api.entryType,
+    targetId: api.targetId,
+    name: api.name,
+    nodeType: api.nodeType,
+    metaFields: api.metaFields.map(toCommitEntryField),
+    contentFields: api.contentFields.map(toCommitEntryField),
+  };
+}
+
+export function toNodeRevision(api: ApiNodeRevision): NodeRevision {
+  return {
+    commitId: api.commitId,
+    message: api.message,
+    commitType: api.commitType,
+    createdAt: api.createdAt,
+    changeType: api.changeType,
+  };
+}
+
+export function toNodeRevisionList(api: ApiNodeRevisionList): NodeRevisionList {
+  return {
+    revisions: api.revisions.map(toNodeRevision),
+    nextCursor: api.nextCursor,
+  };
+}
+
+export function toRestoreResult(api: ApiRestoreResult): RestoreResult {
+  return {
+    backupCommitId: api.backupCommitId,
+    restoreCommitId: api.restoreCommitId,
+  };
+}

--- a/packages/adapter/core/src/adapter.ts
+++ b/packages/adapter/core/src/adapter.ts
@@ -34,6 +34,16 @@ import type {
   AuthState,
   GoogleAuthUrl,
 } from './types';
+import type {
+  Commit,
+  CommitDiff,
+  CommitEntry,
+  CommitList,
+  CreateCommitResult,
+  NodeRevisionList,
+  PaginationParams,
+  RestoreCommitResult,
+} from './version-types';
 
 /**
  * アダプター設定
@@ -334,6 +344,98 @@ export interface AuthAdapter {
 }
 
 /**
+ * バージョン管理（コミット / 差分 / 復元）操作のインターフェース
+ *
+ * コンテンツを変更する API を叩くと、最後の変更から一定時間操作が止まった時点で
+ * `commitType: 'auto'` のコミットがバックエンドで自動生成される。
+ * タイマーはインメモリでサーバー再起動により消えるため、
+ * 「一定時間後に必ずコミットされる」前提の UI（カウントダウン等）を作ってはならない。
+ */
+export interface VersionAdapter {
+  /**
+   * 手動コミット（保存）を作成する
+   *
+   * 前回コミットから変更が無い場合は `{ status: 'no_changes' }` を返す（正常系）。
+   * 保存ボタンを無効化するのではなく、「変更はありません」と穏当に見せること。
+   * @param projectId - プロジェクトID
+   * @param message - コミットメッセージ（1〜500文字）
+   */
+  createCommit(projectId: string, message: string): Promise<CreateCommitResult>;
+
+  /**
+   * プロジェクトのコミット履歴を取得する（新しい順）
+   */
+  listCommits(
+    projectId: string,
+    params?: PaginationParams,
+  ): Promise<CommitList>;
+
+  /**
+   * コミットを 1 件取得する（存在しない場合は null）
+   */
+  getCommit(commitId: string): Promise<Commit | null>;
+
+  /**
+   * コミットの差分を取得する
+   * @param commitId - 差分を見るコミットID
+   * @param baseCommitId - 比較元コミットID。省略時は親コミットとの差分
+   */
+  getCommitDiff(commitId: string, baseCommitId?: string): Promise<CommitDiff>;
+
+  /**
+   * 未コミットの作業差分を取得する
+   *
+   * 返り値の `commitId` は常に null になる。
+   * @param projectId - プロジェクトID
+   * @param baseCommitId - 比較元コミットID。省略時は最新コミットとの差分
+   */
+  getProjectDiff(projectId: string, baseCommitId?: string): Promise<CommitDiff>;
+
+  /**
+   * コミット時点のエントリのスナップショットを取得する（存在しない場合は null）
+   *
+   * 差分 API では `added` / `removed` の中身が返らないため、
+   * 追加された本文を表示したい場合にこれを使う。
+   */
+  getCommitEntry(
+    commitId: string,
+    targetId: string,
+  ): Promise<CommitEntry | null>;
+
+  /**
+   * プロジェクト全体をコミット時点の状態に復元する
+   *
+   * 破壊的操作。復元先に存在しないノード・指示文・用語は物理削除される。
+   * 呼び出し前に必ず確認ダイアログを出すこと。
+   * 復元前の状態は自動でバックアップコミットに退避される
+   * （`RestoreResult.backupCommitId`）。
+   *
+   * `editPolicy` はバージョン管理の対象外であり、復元しても現在の保護設定が維持される。
+   *
+   * 現在の状態が復元先と完全一致している場合は
+   * `{ status: 'already_at_commit' }` を返す（正常系）。
+   */
+  restoreCommit(commitId: string): Promise<RestoreCommitResult>;
+
+  /**
+   * ノードの変更履歴を取得する（新しい順）
+   */
+  listNodeRevisions(
+    nodeId: string,
+    params?: PaginationParams,
+  ): Promise<NodeRevisionList>;
+
+  /**
+   * ノードの本文をコミット時点の状態に復元する
+   *
+   * 本文のみが戻る。名前・親・並び順・canonStatus / contextPolicy は変わらない。
+   * フォルダノードに対して呼ぶとエラー（400）になる。
+   * @returns 復元後のノード（`RestoreResult` ではない）
+   */
+  restoreNode(nodeId: string, commitId: string): Promise<Node>;
+}
+
+/**
  * エクスポート操作のインターフェース
  */
 export interface ExportAdapter {
@@ -360,5 +462,6 @@ export interface Adapter {
   readonly consistency: ConsistencyAdapter;
   readonly glossary: GlossaryAdapter;
   readonly instructions: InstructionAdapter;
+  readonly versions: VersionAdapter;
   readonly export: ExportAdapter;
 }

--- a/packages/adapter/core/src/index.ts
+++ b/packages/adapter/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
+export * from './version-types';
 export * from './adapter';
 export * from './stub';

--- a/packages/adapter/core/src/stub.ts
+++ b/packages/adapter/core/src/stub.ts
@@ -111,6 +111,17 @@ export function createAdapter(_: AdapterConfig = {}): Adapter {
       update: () => notImplemented(),
       delete: () => notImplemented(),
     },
+    versions: {
+      createCommit: () => notImplemented(),
+      listCommits: () => notImplemented(),
+      getCommit: () => notImplemented(),
+      getCommitDiff: () => notImplemented(),
+      getProjectDiff: () => notImplemented(),
+      getCommitEntry: () => notImplemented(),
+      restoreCommit: () => notImplemented(),
+      listNodeRevisions: () => notImplemented(),
+      restoreNode: () => notImplemented(),
+    },
     export: {
       exportProject: () => notImplemented(),
     },

--- a/packages/adapter/core/src/version-types.ts
+++ b/packages/adapter/core/src/version-types.ts
@@ -1,0 +1,235 @@
+/**
+ * バージョン管理（コミット / 差分 / 復元）関連の型定義。
+ */
+import type { NodeType } from './types';
+
+/**
+ * コミットの種別
+ *
+ * - manual: ユーザーが保存ボタンから作成したコミット
+ * - auto: 最後の変更から一定時間操作が止まった時点でバックエンドが自動生成するコミット
+ * - backup: 復元の直前に、復元前の状態を退避するために作られるコミット
+ * - restore: 復元によって作られるコミット
+ */
+export type CommitType = 'manual' | 'auto' | 'backup' | 'restore';
+
+/**
+ * コミットに含まれるエントリ（変更対象）の種別
+ */
+export type RevisionEntryType =
+  | 'project'
+  | 'node'
+  | 'instruction'
+  | 'glossary_term';
+
+/**
+ * 差分エントリの変更種別
+ */
+export type DiffChangeType = 'added' | 'removed' | 'modified';
+
+/**
+ * 行差分の操作種別
+ *
+ * - eq: 変更なし
+ * - add: 追加された行
+ * - del: 削除された行
+ */
+export type DiffLineOp = 'eq' | 'add' | 'del';
+
+/**
+ * コミット
+ *
+ * addedCount / modifiedCount / removedCount は「エントリ（変更対象）の件数」であり、
+ * 文字数や行数ではない。
+ */
+export interface Commit {
+  id: string;
+  projectId: string;
+  /** 親コミットID（最初のコミットは null） */
+  parentId: string | null;
+  /** コミットメッセージ */
+  message: string;
+  commitType: CommitType;
+  /** 追加されたエントリ件数 */
+  addedCount: number;
+  /** 変更されたエントリ件数 */
+  modifiedCount: number;
+  /** 削除されたエントリ件数 */
+  removedCount: number;
+  createdAt: Date;
+}
+
+/**
+ * コミット一覧（カーソルページネーション）
+ *
+ * `has_more` は存在しない。`nextCursor === null` が終端を意味する。
+ */
+export interface CommitList {
+  commits: Commit[];
+  /** 次ページのカーソル。null なら終端 */
+  nextCursor: string | null;
+}
+
+/**
+ * 短い属性フィールドの before/after
+ *
+ * `name` / `role` / `tags` / `canonStatus` などの短い属性が対象。
+ * 値が変わっていないフィールドは含まれない。
+ */
+export interface DiffFieldChange {
+  /** フィールド名 */
+  field: string;
+  /** 変更前の値（存在しなかった場合は null） */
+  oldValue: string | null;
+  /** 変更後の値（削除された場合は null） */
+  newValue: string | null;
+}
+
+/**
+ * 行単位差分の 1 行
+ */
+export interface DiffLine {
+  op: DiffLineOp;
+  text: string;
+}
+
+/**
+ * 長文フィールドの行単位差分
+ *
+ * `content` / `synopsis` / `notes` などの長文が対象。
+ * 差分はバックエンドで計算済みのため、フロントで差分ライブラリを使う必要はない。
+ */
+export interface TextDiff {
+  /** フィールド名 */
+  field: string;
+  lines: DiffLine[];
+}
+
+/**
+ * 差分エントリ（変更対象 1 件分の差分）
+ *
+ * changeType が `added` / `removed` の場合、fieldChanges と textDiffs は必ず空配列になる。
+ * 追加された本文の中身を見せたい場合は `getCommitEntry()` を別途呼ぶこと。
+ *
+ * ノード種別が途中で変わった場合はメタ情報の fieldChanges のみが返る。
+ */
+export interface CommitDiffEntry {
+  entryType: RevisionEntryType;
+  /** 変更対象のID（ノードID / 指示ID / 用語ID / プロジェクトID） */
+  targetId: string;
+  changeType: DiffChangeType;
+  /** 変更対象の表示名 */
+  name: string;
+  /** ノード種別（entryType が node 以外の場合は null） */
+  nodeType: NodeType | null;
+  /** 短い属性の before/after（added / removed では空配列） */
+  fieldChanges: DiffFieldChange[];
+  /** 長文の行単位差分（added / removed では空配列） */
+  textDiffs: TextDiff[];
+}
+
+/**
+ * コミット差分
+ */
+export interface CommitDiff {
+  /** 比較元のコミットID（親コミットが無い場合は null） */
+  baseCommitId: string | null;
+  /** 比較先のコミットID。作業差分（未コミット）の場合は常に null */
+  commitId: string | null;
+  entries: CommitDiffEntry[];
+}
+
+/**
+ * コミットエントリのフィールド 1 件
+ */
+export interface CommitEntryField {
+  field: string;
+  value: string | null;
+}
+
+/**
+ * コミット時点のエントリのスナップショット
+ *
+ * 差分 API では返らない「追加された本文の中身」を取得するために使う。
+ */
+export interface CommitEntry {
+  entryType: RevisionEntryType;
+  targetId: string;
+  name: string;
+  /** ノード種別（entryType が node 以外の場合は null） */
+  nodeType: NodeType | null;
+  /** 短い属性フィールド */
+  metaFields: CommitEntryField[];
+  /** 長文フィールド */
+  contentFields: CommitEntryField[];
+}
+
+/**
+ * ノード単位の変更履歴における変更種別
+ */
+export type NodeRevisionChangeType = 'added' | 'modified';
+
+/**
+ * ノード単位の変更履歴（そのノードを変更したコミット）
+ */
+export interface NodeRevision {
+  commitId: string;
+  message: string;
+  commitType: CommitType;
+  createdAt: Date;
+  changeType: NodeRevisionChangeType;
+}
+
+/**
+ * ノード変更履歴一覧（カーソルページネーション）
+ *
+ * `nextCursor === null` が終端を意味する。
+ */
+export interface NodeRevisionList {
+  revisions: NodeRevision[];
+  /** 次ページのカーソル。null なら終端 */
+  nextCursor: string | null;
+}
+
+/**
+ * コミット作成の結果
+ *
+ * 「変更がない」はバックエンドが 409 で返す**正常系**であり、
+ * 通信エラーとは区別して穏当に扱えるよう結果型で表している。
+ */
+export type CreateCommitResult =
+  | { status: 'created'; commit: Commit }
+  /** 前回コミットから変更がなかった（保存するものが無い） */
+  | { status: 'no_changes' };
+
+/**
+ * 復元の結果
+ */
+export interface RestoreResult {
+  /** 復元前の状態を退避したバックアップコミットID（未コミット変更が無ければ null） */
+  backupCommitId: string | null;
+  /** 復元によって作られたコミットID */
+  restoreCommitId: string;
+}
+
+/**
+ * プロジェクト全体の復元の結果
+ *
+ * 「既にこの状態」はバックエンドが 409 で返す**正常系**であり、
+ * 通信エラーとは区別して穏当に扱えるよう結果型で表している。
+ */
+export type RestoreCommitResult =
+  | { status: 'restored'; result: RestoreResult }
+  /** 現在の状態が復元先と完全に一致していた */
+  | { status: 'already_at_commit' };
+
+/**
+ * カーソルページネーションのパラメータ
+ *
+ * limit はデフォルト 50 / 最大 100。範囲外の値はバックエンド側で黙って丸められる。
+ * cursor にはレスポンスの nextCursor をそのまま渡す。
+ */
+export interface PaginationParams {
+  limit?: number;
+  cursor?: string | null;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,6 +33,7 @@
     "dev:tauri": "vite build --watch",
     "dev:web": "vite build --watch",
     "lint": "eslint --fix",
+    "tsc": "tsc --noEmit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "start-storybook": "npx http-server ./storybook-static -p 6006",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,7 +36,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "start-storybook": "npx http-server ./storybook-static -p 6006",
-    "test": "jest"
+    "test": "TZ=Asia/Tokyo jest"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/packages/ui/src/components/features/index.ts
+++ b/packages/ui/src/components/features/index.ts
@@ -10,3 +10,4 @@ export * from './instructions';
 export * from './node-ai-attributes';
 export * from './project-list';
 export * from './sidebar';
+export * from './version-history';

--- a/packages/ui/src/components/features/version-history/commit-diff-view.stories.tsx
+++ b/packages/ui/src/components/features/version-history/commit-diff-view.stories.tsx
@@ -45,6 +45,13 @@ export const Loading: Story = {
   },
 };
 
+export const LoadFailed: Story = {
+  args: {
+    entries: [],
+    hasError: true,
+  },
+};
+
 const mockEntryContents: Record<string, CommitEntryContentItem> = {
   node_memo_9: {
     metaFields: [{ field: 'canon_status', value: 'draft' }],

--- a/packages/ui/src/components/features/version-history/commit-diff-view.stories.tsx
+++ b/packages/ui/src/components/features/version-history/commit-diff-view.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import * as React from 'react';
+import {
+  CommitDiffView,
+  type CommitEntryContentItem,
+} from './commit-diff-view';
+import { mockDiffEntries } from './mock-data';
+
+const meta = {
+  title: 'Features/CommitDiffView',
+  component: CommitDiffView,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ height: '600px', maxWidth: '720px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CommitDiffView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    entries: mockDiffEntries,
+    title: '第二章の視点を三人称に統一した',
+    subtitle: 'commit_3 との差分',
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    entries: [],
+    title: '未コミットの変更',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    entries: [],
+    isLoading: true,
+  },
+};
+
+const mockEntryContents: Record<string, CommitEntryContentItem> = {
+  node_memo_9: {
+    metaFields: [{ field: 'canon_status', value: 'draft' }],
+    contentFields: [
+      {
+        field: 'content',
+        value:
+          '図書室の鍵は司書室の引き出しにある。\n第四章で彼女が持ち出す前提で書く。',
+      },
+      { field: 'tags', value: '伏線, 小道具' },
+    ],
+  },
+  term_3: {
+    metaFields: [],
+    contentFields: [
+      { field: 'term', value: '旧校舎' },
+      { field: 'reading', value: 'きゅうこうしゃ' },
+      { field: 'notes', value: '第三章以降は使わない設定に変更したため削除。' },
+    ],
+  },
+};
+
+export const Interactive: StoryObj = {
+  render: () => {
+    const [entryContents, setEntryContents] = React.useState<
+      Record<string, CommitEntryContentItem | undefined>
+    >({});
+    const [loadingEntryIds, setLoadingEntryIds] = React.useState<string[]>([]);
+
+    // added / removed の中身は差分APIに含まれないため、別途取得する動きを再現する
+    const handleShowEntryContent = (targetId: string) => {
+      setLoadingEntryIds((prev) => [...prev, targetId]);
+      setTimeout(() => {
+        setEntryContents((prev) => ({
+          ...prev,
+          [targetId]: mockEntryContents[targetId],
+        }));
+        setLoadingEntryIds((prev) => prev.filter((id) => id !== targetId));
+      }, 400);
+    };
+
+    return (
+      <CommitDiffView
+        entries={mockDiffEntries}
+        title="第二章の視点を三人称に統一した"
+        subtitle="親コミットとの差分"
+        entryContents={entryContents}
+        loadingEntryIds={loadingEntryIds}
+        onShowEntryContent={handleShowEntryContent}
+      />
+    );
+  },
+};

--- a/packages/ui/src/components/features/version-history/commit-diff-view.tsx
+++ b/packages/ui/src/components/features/version-history/commit-diff-view.tsx
@@ -1,0 +1,343 @@
+import * as React from 'react';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { Eye, Loader2 } from 'lucide-react';
+import {
+  buildDiffRows,
+  countDiffLineOps,
+  type DiffChangeTypeValue,
+  type DiffLineOpValue,
+  type RevisionEntryTypeValue,
+} from '@/lib/version-history-utils';
+import { ChangeTypeBadge, entryKindLabel, fieldLabel } from './version-badges';
+
+/** 短い属性フィールドの before/after */
+export interface DiffFieldChangeItem {
+  field: string;
+  oldValue: string | null;
+  newValue: string | null;
+}
+
+/** 行差分の 1 行 */
+export interface DiffLineItem {
+  op: DiffLineOpValue;
+  text: string;
+}
+
+/** 長文フィールドの行単位差分 */
+export interface TextDiffItem {
+  field: string;
+  lines: DiffLineItem[];
+}
+
+/** 差分エントリ（変更対象 1 件分） */
+export interface CommitDiffEntryItem {
+  entryType: RevisionEntryTypeValue;
+  targetId: string;
+  changeType: DiffChangeTypeValue;
+  name: string;
+  nodeType: string | null;
+  /** 短い属性の before/after。added / removed では空配列 */
+  fieldChanges: DiffFieldChangeItem[];
+  /** 長文の行単位差分。added / removed では空配列 */
+  textDiffs: TextDiffItem[];
+}
+
+/** コミット時点のエントリのスナップショット（added / removed の中身表示用） */
+export interface CommitEntryContentItem {
+  metaFields: { field: string; value: string | null }[];
+  contentFields: { field: string; value: string | null }[];
+}
+
+export interface CommitDiffViewProps {
+  entries: CommitDiffEntryItem[];
+  /** 見出し（例: コミットメッセージ、「未コミットの変更」） */
+  title?: string;
+  /** 補足行（例: 比較元コミット） */
+  subtitle?: string | null;
+  isLoading?: boolean;
+  /**
+   * added / removed エントリの中身を取得する。
+   * 差分APIは追加・削除された本文を返さないため、別途取得が必要。
+   */
+  onShowEntryContent?: (targetId: string) => void;
+  /** 取得済みのエントリ内容（targetId をキーにする） */
+  entryContents?: Record<string, CommitEntryContentItem | undefined>;
+  /** 内容を取得中のエントリID */
+  loadingEntryIds?: string[];
+  /** 空のときに出すメッセージ */
+  emptyMessage?: string;
+  className?: string;
+}
+
+const LINE_OP_META: Record<
+  DiffLineOpValue,
+  { symbol: string; rowClassName: string }
+> = {
+  eq: { symbol: ' ', rowClassName: '' },
+  add: {
+    symbol: '+',
+    rowClassName:
+      'bg-green-50 text-green-900 dark:bg-green-950/40 dark:text-green-200',
+  },
+  del: {
+    symbol: '−',
+    rowClassName: 'bg-red-50 text-red-900 dark:bg-red-950/40 dark:text-red-200',
+  },
+};
+
+function FieldChangeRow({ change }: { change: DiffFieldChangeItem }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs font-medium text-muted-foreground">
+        {fieldLabel(change.field)}
+      </p>
+      <div className="grid gap-1 sm:grid-cols-2">
+        <div className="min-w-0 rounded border-l-2 border-destructive bg-red-50 px-2 py-1 dark:bg-red-950/30">
+          <p className="text-[10px] text-muted-foreground">変更前</p>
+          <p className="break-words whitespace-pre-wrap text-xs">
+            {change.oldValue ?? (
+              <span className="text-muted-foreground">（なし）</span>
+            )}
+          </p>
+        </div>
+        <div className="min-w-0 rounded border-l-2 border-green-500 bg-green-50 px-2 py-1 dark:bg-green-950/30">
+          <p className="text-[10px] text-muted-foreground">変更後</p>
+          <p className="break-words whitespace-pre-wrap text-xs">
+            {change.newValue ?? (
+              <span className="text-muted-foreground">（なし）</span>
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TextDiffBlock({ textDiff }: { textDiff: TextDiffItem }) {
+  const rows = React.useMemo(
+    () => buildDiffRows(textDiff.lines),
+    [textDiff.lines],
+  );
+  const { added, removed } = React.useMemo(
+    () => countDiffLineOps(textDiff.lines),
+    [textDiff.lines],
+  );
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        <p className="text-xs font-medium text-muted-foreground">
+          {fieldLabel(textDiff.field)}
+        </p>
+        <p className="font-mono text-[10px] text-muted-foreground">
+          <span className="text-green-600 dark:text-green-400">+{added}</span>{' '}
+          <span className="text-destructive">−{removed}</span>
+        </p>
+      </div>
+      <div className="overflow-hidden rounded border font-mono text-xs">
+        {rows.map((row, index) =>
+          row.kind === 'gap' ? (
+            <div
+              key={`gap-${index}`}
+              className="bg-muted/60 px-2 py-0.5 text-center text-[10px] text-muted-foreground"
+            >
+              … 変更のない {row.hiddenCount} 行を省略
+            </div>
+          ) : (
+            <div
+              key={`line-${index}`}
+              className={cn(
+                'flex gap-2 px-2',
+                LINE_OP_META[row.op].rowClassName,
+              )}
+            >
+              <span
+                aria-hidden
+                className="w-8 shrink-0 select-none text-right text-muted-foreground"
+              >
+                {row.oldLineNumber ?? ''}
+              </span>
+              <span
+                aria-hidden
+                className="w-8 shrink-0 select-none text-right text-muted-foreground"
+              >
+                {row.newLineNumber ?? ''}
+              </span>
+              <span aria-hidden className="w-2 shrink-0 select-none">
+                {LINE_OP_META[row.op].symbol}
+              </span>
+              <span className="min-w-0 break-words whitespace-pre-wrap">
+                {row.text === '' ? ' ' : row.text}
+              </span>
+            </div>
+          ),
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EntryContentBlock({ content }: { content: CommitEntryContentItem }) {
+  const fields = [...content.metaFields, ...content.contentFields].filter(
+    (field) => field.value !== null && field.value !== '',
+  );
+
+  if (fields.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        表示できる内容がありません。
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {fields.map((field) => (
+        <div key={field.field} className="space-y-1">
+          <p className="text-xs font-medium text-muted-foreground">
+            {fieldLabel(field.field)}
+          </p>
+          <p className="break-words whitespace-pre-wrap rounded bg-muted px-2 py-1 font-mono text-xs">
+            {field.value}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DiffEntryCard({
+  entry,
+  content,
+  isLoadingContent,
+  onShowEntryContent,
+}: {
+  entry: CommitDiffEntryItem;
+  content: CommitEntryContentItem | undefined;
+  isLoadingContent: boolean;
+  onShowEntryContent?: (targetId: string) => void;
+}) {
+  // added / removed では差分APIが中身を返さないため、別途取得して見せる
+  const needsContentFetch =
+    entry.changeType !== 'modified' && onShowEntryContent !== undefined;
+  const hasDiffBody =
+    entry.fieldChanges.length > 0 || entry.textDiffs.length > 0;
+
+  return (
+    <div className="space-y-2 rounded-md border p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <ChangeTypeBadge changeType={entry.changeType} />
+        <span className="inline-flex shrink-0 items-center rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+          {entryKindLabel(entry.entryType, entry.nodeType)}
+        </span>
+        <span className="min-w-0 truncate text-sm font-medium">
+          {entry.name}
+        </span>
+      </div>
+
+      {entry.fieldChanges.length > 0 && (
+        <div className="space-y-2">
+          {entry.fieldChanges.map((change) => (
+            <FieldChangeRow key={change.field} change={change} />
+          ))}
+        </div>
+      )}
+
+      {entry.textDiffs.map((textDiff) => (
+        <TextDiffBlock key={textDiff.field} textDiff={textDiff} />
+      ))}
+
+      {!hasDiffBody && (
+        <div className="space-y-2">
+          {content ? (
+            <EntryContentBlock content={content} />
+          ) : (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {entry.changeType === 'added'
+                  ? 'このエントリの中身は差分に含まれません。'
+                  : 'このエントリは削除されました。削除前の中身は差分に含まれません。'}
+              </p>
+              {needsContentFetch && (
+                <Button
+                  size="xs"
+                  variant="outline"
+                  disabled={isLoadingContent}
+                  onClick={() => onShowEntryContent?.(entry.targetId)}
+                >
+                  {isLoadingContent ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    <Eye className="size-3" />
+                  )}
+                  中身を表示
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * コミット差分（または未コミットの作業差分）を表示する。
+ * 差分はバックエンドで計算済みのものをそのまま描画する（表示専用コンポーネント）。
+ */
+export function CommitDiffView({
+  entries,
+  title,
+  subtitle,
+  isLoading = false,
+  onShowEntryContent,
+  entryContents,
+  loadingEntryIds,
+  emptyMessage = '変更はありません。',
+  className,
+}: CommitDiffViewProps) {
+  const loadingIds = React.useMemo(
+    () => new Set(loadingEntryIds ?? []),
+    [loadingEntryIds],
+  );
+
+  return (
+    <div className={cn('flex h-full min-h-0 flex-col', className)}>
+      {(title !== undefined || subtitle) && (
+        <div className="shrink-0 border-b px-3 py-2">
+          {title !== undefined && (
+            <h3 className="truncate text-sm font-semibold">{title}</h3>
+          )}
+          {subtitle && (
+            <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
+          )}
+        </div>
+      )}
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="space-y-3 p-3">
+          {isLoading ? (
+            <p className="animate-pulse py-8 text-center text-sm text-muted-foreground">
+              差分を読み込んでいます…
+            </p>
+          ) : entries.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              {emptyMessage}
+            </p>
+          ) : (
+            entries.map((entry) => (
+              <DiffEntryCard
+                key={`${entry.entryType}-${entry.targetId}`}
+                entry={entry}
+                content={entryContents?.[entry.targetId]}
+                isLoadingContent={loadingIds.has(entry.targetId)}
+                onShowEntryContent={onShowEntryContent}
+              />
+            ))
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/packages/ui/src/components/features/version-history/commit-diff-view.tsx
+++ b/packages/ui/src/components/features/version-history/commit-diff-view.tsx
@@ -11,6 +11,7 @@ import {
   type RevisionEntryTypeValue,
 } from '@/lib/version-history-utils';
 import { ChangeTypeBadge, entryKindLabel, fieldLabel } from './version-badges';
+import { LoadErrorState } from './load-error-state';
 
 /** 短い属性フィールドの before/after */
 export interface DiffFieldChangeItem {
@@ -68,6 +69,12 @@ export interface CommitDiffViewProps {
   loadingEntryIds?: string[];
   /** 空のときに出すメッセージ */
   emptyMessage?: string;
+  /**
+   * 差分の取得に失敗したか。
+   * 「差分がない」と区別できるよう、空表示ではなくエラー表示にする。
+   */
+  hasError?: boolean;
+  onRetry?: () => void;
   className?: string;
 }
 
@@ -85,6 +92,17 @@ const LINE_OP_META: Record<
     symbol: '−',
     rowClassName: 'bg-red-50 text-red-900 dark:bg-red-950/40 dark:text-red-200',
   },
+};
+
+/**
+ * 差分の本体（field_changes / text_diffs）が空だったときの説明文。
+ * added / removed は差分APIが中身を返さない仕様。
+ * modified でも、ノード種別が変わった場合などにメタ情報だけになり得る。
+ */
+const EMPTY_BODY_MESSAGES: Record<DiffChangeTypeValue, string> = {
+  added: 'このエントリの中身は差分に含まれません。',
+  removed: 'このエントリは削除されました。削除前の中身は差分に含まれません。',
+  modified: 'このエントリの変更内容は差分に含まれていません。',
 };
 
 function FieldChangeRow({ change }: { change: DiffFieldChangeItem }) {
@@ -219,11 +237,12 @@ function DiffEntryCard({
   isLoadingContent: boolean;
   onShowEntryContent?: (targetId: string) => void;
 }) {
-  // added / removed では差分APIが中身を返さないため、別途取得して見せる
-  const needsContentFetch =
-    entry.changeType !== 'modified' && onShowEntryContent !== undefined;
   const hasDiffBody =
     entry.fieldChanges.length > 0 || entry.textDiffs.length > 0;
+  // added / removed では差分APIが中身を返さない。
+  // modified でも（ノード種別が変わった場合など）中身が空になり得るため、
+  // 差分の本体が無いエントリは種別にかかわらず取得できるようにする。
+  const needsContentFetch = !hasDiffBody && onShowEntryContent !== undefined;
 
   return (
     <div className="space-y-2 rounded-md border p-3">
@@ -256,9 +275,7 @@ function DiffEntryCard({
           ) : (
             <>
               <p className="text-xs text-muted-foreground">
-                {entry.changeType === 'added'
-                  ? 'このエントリの中身は差分に含まれません。'
-                  : 'このエントリは削除されました。削除前の中身は差分に含まれません。'}
+                {EMPTY_BODY_MESSAGES[entry.changeType]}
               </p>
               {needsContentFetch && (
                 <Button
@@ -296,6 +313,8 @@ export function CommitDiffView({
   entryContents,
   loadingEntryIds,
   emptyMessage = '変更はありません。',
+  hasError = false,
+  onRetry,
   className,
 }: CommitDiffViewProps) {
   const loadingIds = React.useMemo(
@@ -321,6 +340,12 @@ export function CommitDiffView({
             <p className="animate-pulse py-8 text-center text-sm text-muted-foreground">
               差分を読み込んでいます…
             </p>
+          ) : hasError ? (
+            // 「差分がない」と誤解させないよう、空表示ではなくエラーとして見せる
+            <LoadErrorState
+              message="差分を読み込めませんでした。"
+              onRetry={onRetry}
+            />
           ) : entries.length === 0 ? (
             <p className="py-8 text-center text-sm text-muted-foreground">
               {emptyMessage}

--- a/packages/ui/src/components/features/version-history/commit-timeline.stories.tsx
+++ b/packages/ui/src/components/features/version-history/commit-timeline.stories.tsx
@@ -1,0 +1,174 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import * as React from 'react';
+import { CommitTimeline, type CommitTimelineItem } from './commit-timeline';
+import { CommitDiffView } from './commit-diff-view';
+import { mockCommits, mockDiffEntries } from './mock-data';
+
+const meta = {
+  title: 'Features/CommitTimeline',
+  component: CommitTimeline,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ height: '600px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CommitTimeline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    commits: mockCommits,
+    hasUncommittedChanges: true,
+    selectedCommitId: 'commit_4',
+    hasMore: true,
+    detail: (
+      <CommitDiffView
+        entries={mockDiffEntries}
+        title="第二章の視点を三人称に統一した"
+        subtitle="commit_3 との差分"
+      />
+    ),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    commits: [],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    commits: [],
+    isLoading: true,
+  },
+};
+
+export const NoChangesNotice: Story = {
+  args: {
+    commits: mockCommits,
+    notice: '変更はありません。',
+  },
+};
+
+export const AfterRestore: Story = {
+  args: {
+    commits: mockCommits,
+    undoBackupCommitId: 'commit_2',
+  },
+};
+
+export const Interactive: StoryObj = {
+  render: () => {
+    const [commits, setCommits] =
+      React.useState<CommitTimelineItem[]>(mockCommits);
+    const [selectedCommitId, setSelectedCommitId] = React.useState<
+      string | null
+    >('commit_4');
+    const [isUncommittedSelected, setIsUncommittedSelected] =
+      React.useState(false);
+    const [hasUncommittedChanges, setHasUncommittedChanges] =
+      React.useState(true);
+    const [notice, setNotice] = React.useState<string | null>(null);
+    const [undoBackupCommitId, setUndoBackupCommitId] = React.useState<
+      string | null
+    >(null);
+
+    const selected = commits.find((commit) => commit.id === selectedCommitId);
+
+    const handleSave = (message: string) => {
+      if (!hasUncommittedChanges) {
+        // 409 が正常系として返るケースを模した穏当な通知
+        setNotice('変更はありません。');
+        return;
+      }
+      const created: CommitTimelineItem = {
+        id: `commit_${commits.length + 6}`,
+        message,
+        commitType: 'manual',
+        addedCount: 0,
+        modifiedCount: 1,
+        removedCount: 0,
+        createdAt: new Date('2026-08-04T19:30:00'),
+      };
+      setCommits((prev) => [created, ...prev]);
+      setHasUncommittedChanges(false);
+      setIsUncommittedSelected(false);
+      setSelectedCommitId(created.id);
+      setNotice(null);
+    };
+
+    const handleRestore = (commitId: string) => {
+      const target = commits.find((commit) => commit.id === commitId);
+      const backup: CommitTimelineItem = {
+        id: `commit_backup_${commitId}`,
+        message: '復元前の自動バックアップ',
+        commitType: 'backup',
+        addedCount: 0,
+        modifiedCount: 1,
+        removedCount: 0,
+        createdAt: new Date('2026-08-04T19:40:00'),
+      };
+      const restore: CommitTimelineItem = {
+        id: `commit_restore_${commitId}`,
+        message: `「${target?.message ?? ''}」の時点に復元`,
+        commitType: 'restore',
+        addedCount: 0,
+        modifiedCount: 2,
+        removedCount: 1,
+        createdAt: new Date('2026-08-04T19:41:00'),
+      };
+      setCommits((prev) => [restore, backup, ...prev]);
+      setUndoBackupCommitId(backup.id);
+      setHasUncommittedChanges(false);
+      setSelectedCommitId(restore.id);
+    };
+
+    return (
+      <CommitTimeline
+        commits={commits}
+        hasUncommittedChanges={hasUncommittedChanges}
+        selectedCommitId={selectedCommitId}
+        isUncommittedSelected={isUncommittedSelected}
+        notice={notice}
+        onDismissNotice={() => setNotice(null)}
+        undoBackupCommitId={undoBackupCommitId}
+        onUndoRestore={(backupCommitId) => handleRestore(backupCommitId)}
+        onDismissUndo={() => setUndoBackupCommitId(null)}
+        onSave={handleSave}
+        onSelectCommit={(commitId) => {
+          setSelectedCommitId(commitId);
+          setIsUncommittedSelected(false);
+        }}
+        onSelectUncommitted={() => {
+          setIsUncommittedSelected(true);
+          setSelectedCommitId(null);
+        }}
+        onRestore={handleRestore}
+        detail={
+          isUncommittedSelected ? (
+            <CommitDiffView
+              entries={mockDiffEntries.slice(0, 1)}
+              title="未コミットの変更"
+              subtitle="最新コミットとの差分"
+            />
+          ) : selected ? (
+            <CommitDiffView
+              entries={mockDiffEntries}
+              title={selected.message}
+              subtitle="親コミットとの差分"
+            />
+          ) : (
+            <CommitDiffView entries={[]} />
+          )
+        }
+      />
+    );
+  },
+};

--- a/packages/ui/src/components/features/version-history/commit-timeline.stories.tsx
+++ b/packages/ui/src/components/features/version-history/commit-timeline.stories.tsx
@@ -57,6 +57,13 @@ export const NoChangesNotice: Story = {
   },
 };
 
+export const LoadFailed: Story = {
+  args: {
+    commits: [],
+    hasError: true,
+  },
+};
+
 export const AfterRestore: Story = {
   args: {
     commits: mockCommits,

--- a/packages/ui/src/components/features/version-history/commit-timeline.tsx
+++ b/packages/ui/src/components/features/version-history/commit-timeline.tsx
@@ -1,0 +1,461 @@
+import * as React from 'react';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+import {
+  History,
+  Loader2,
+  RefreshCw,
+  RotateCcw,
+  Save,
+  Undo2,
+  X,
+} from 'lucide-react';
+import {
+  COMMIT_MESSAGE_MAX_LENGTH,
+  formatChangeCounts,
+  groupByDay,
+  validateCommitMessage,
+  type CommitTypeValue,
+} from '@/lib/version-history-utils';
+import {
+  CommitTypeBadge,
+  formatDateHeading,
+  formatTimeOfDay,
+} from './version-badges';
+
+/** タイムラインに並べるコミット */
+export interface CommitTimelineItem {
+  id: string;
+  message: string;
+  commitType: CommitTypeValue;
+  /** 追加されたエントリ件数（文字数や行数ではない） */
+  addedCount: number;
+  /** 変更されたエントリ件数 */
+  modifiedCount: number;
+  /** 削除されたエントリ件数 */
+  removedCount: number;
+  createdAt: Date;
+}
+
+export interface CommitTimelineProps {
+  commits: CommitTimelineItem[];
+  /** 未コミットの作業差分があるか */
+  hasUncommittedChanges?: boolean;
+  /** 選択中のコミットID */
+  selectedCommitId?: string | null;
+  /** 未コミットの作業差分が選択されているか */
+  isUncommittedSelected?: boolean;
+  isLoading?: boolean;
+  isLoadingMore?: boolean;
+  /** 次ページがあるか（next_cursor !== null） */
+  hasMore?: boolean;
+  isSaving?: boolean;
+  isRestoring?: boolean;
+  /** 穏当に見せる通知（例: 「変更はありません」） */
+  notice?: string | null;
+  onDismissNotice?: () => void;
+  /** 直前の復元で作られたバックアップコミットID（「元に戻す」導線） */
+  undoBackupCommitId?: string | null;
+  onUndoRestore?: (backupCommitId: string) => void;
+  onDismissUndo?: () => void;
+  onSave?: (message: string) => void;
+  onSelectCommit?: (commitId: string) => void;
+  onSelectUncommitted?: () => void;
+  onRestore?: (commitId: string) => void;
+  onLoadMore?: () => void;
+  onRefresh?: () => void;
+  /** 右側に並べる差分ビュー */
+  detail?: React.ReactNode;
+  className?: string;
+}
+
+function SaveForm({
+  isSaving,
+  onSave,
+}: {
+  isSaving: boolean;
+  onSave?: (message: string) => void;
+}) {
+  const [message, setMessage] = React.useState('');
+  const [touched, setTouched] = React.useState(false);
+  const error = validateCommitMessage(message);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setTouched(true);
+    if (error !== null) return;
+    onSave?.(message.trim());
+    setMessage('');
+    setTouched(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-1.5">
+      <div className="flex gap-2">
+        <Input
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          onBlur={() => setTouched(true)}
+          placeholder="変更内容を書いて保存（例: 第一章を書き上げた）"
+          maxLength={COMMIT_MESSAGE_MAX_LENGTH}
+          aria-label="コミットメッセージ"
+          aria-invalid={touched && error !== null}
+          disabled={isSaving}
+        />
+        <Button type="submit" size="sm" disabled={isSaving}>
+          {isSaving ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Save className="size-4" />
+          )}
+          保存
+        </Button>
+      </div>
+      {touched && error !== null && (
+        <p className="text-xs text-destructive">{error}</p>
+      )}
+    </form>
+  );
+}
+
+function NoticeBanner({
+  message,
+  onDismiss,
+}: {
+  message: string;
+  onDismiss?: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-2 rounded-md bg-muted px-2.5 py-2"
+    >
+      <p className="min-w-0 flex-1 text-xs text-muted-foreground">{message}</p>
+      {onDismiss && (
+        <Button
+          size="icon-xs"
+          variant="ghost"
+          aria-label="通知を閉じる"
+          onClick={onDismiss}
+        >
+          <X className="size-3" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function UndoBanner({
+  backupCommitId,
+  isRestoring,
+  onUndoRestore,
+  onDismiss,
+}: {
+  backupCommitId: string;
+  isRestoring: boolean;
+  onUndoRestore?: (backupCommitId: string) => void;
+  onDismiss?: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-2.5 py-2 dark:border-amber-800 dark:bg-amber-950/40"
+    >
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <p className="text-xs">
+          復元しました。復元前の状態はバックアップコミットに保存されています。
+        </p>
+        <Button
+          size="xs"
+          variant="outline"
+          disabled={isRestoring}
+          onClick={() => onUndoRestore?.(backupCommitId)}
+        >
+          {isRestoring ? (
+            <Loader2 className="size-3 animate-spin" />
+          ) : (
+            <Undo2 className="size-3" />
+          )}
+          元に戻す
+        </Button>
+      </div>
+      {onDismiss && (
+        <Button
+          size="icon-xs"
+          variant="ghost"
+          aria-label="通知を閉じる"
+          onClick={onDismiss}
+        >
+          <X className="size-3" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function CommitRow({
+  commit,
+  isSelected,
+  isRestoring,
+  onSelect,
+  onRequestRestore,
+}: {
+  commit: CommitTimelineItem;
+  isSelected: boolean;
+  isRestoring: boolean;
+  onSelect?: () => void;
+  onRequestRestore?: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'group/commit rounded-md border px-2.5 py-2 transition-colors',
+        isSelected ? 'border-primary bg-accent' : 'hover:bg-accent/50',
+      )}
+    >
+      <button
+        type="button"
+        className="w-full text-left"
+        aria-current={isSelected}
+        onClick={onSelect}
+      >
+        <div className="flex items-center gap-2">
+          <CommitTypeBadge commitType={commit.commitType} />
+          <span className="ml-auto shrink-0 font-mono text-[10px] text-muted-foreground">
+            {formatTimeOfDay(commit.createdAt)}
+          </span>
+        </div>
+        <p className="mt-1 line-clamp-2 text-xs font-medium">
+          {commit.message}
+        </p>
+        <p className="mt-0.5 text-[10px] text-muted-foreground">
+          {formatChangeCounts({
+            added: commit.addedCount,
+            modified: commit.modifiedCount,
+            removed: commit.removedCount,
+          })}
+        </p>
+      </button>
+      <div className="mt-1 flex justify-end">
+        <Button
+          size="xs"
+          variant="ghost"
+          className="opacity-0 transition-opacity group-hover/commit:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100"
+          disabled={isRestoring}
+          onClick={onRequestRestore}
+        >
+          <RotateCcw className="size-3" />
+          この状態に戻す
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * プロジェクトの変更履歴タイムライン。
+ *
+ * コミット種別（保存 / 自動保存 / バックアップ / 復元）で見た目を分け、
+ * 保存ボタン・未コミット変更の表示・コミット単位の復元導線を持つ。
+ * 復元は破壊的なため、必ず確認ダイアログを経由する。
+ *
+ * 自動保存コミットはバックエンドが勝手に増やすため、`onRefresh` で再取得できるようにしている。
+ * 表示専用コンポーネント（データ取得は行わない）。
+ */
+export function CommitTimeline({
+  commits,
+  hasUncommittedChanges = false,
+  selectedCommitId = null,
+  isUncommittedSelected = false,
+  isLoading = false,
+  isLoadingMore = false,
+  hasMore = false,
+  isSaving = false,
+  isRestoring = false,
+  notice = null,
+  onDismissNotice,
+  undoBackupCommitId = null,
+  onUndoRestore,
+  onDismissUndo,
+  onSave,
+  onSelectCommit,
+  onSelectUncommitted,
+  onRestore,
+  onLoadMore,
+  onRefresh,
+  detail,
+  className,
+}: CommitTimelineProps) {
+  const [restoreTarget, setRestoreTarget] =
+    React.useState<CommitTimelineItem | null>(null);
+
+  const groups = React.useMemo(
+    () => groupByDay(commits, (commit) => commit.createdAt),
+    [commits],
+  );
+
+  const handleConfirmRestore = () => {
+    if (restoreTarget === null) return;
+    onRestore?.(restoreTarget.id);
+    setRestoreTarget(null);
+  };
+
+  return (
+    <div className={cn('flex h-full min-h-0 flex-col md:flex-row', className)}>
+      {/* 狭い画面では縦積み、md 以上で左カラム固定の2カラム */}
+      <div className="flex max-h-72 min-w-0 flex-col border-b md:h-full md:max-h-none md:w-72 md:shrink-0 md:border-b-0 md:border-r">
+        {/* ヘッダー + 保存 */}
+        <div className="shrink-0 space-y-2 border-b px-3 py-2">
+          <div className="flex items-center justify-between">
+            <h2 className="flex items-center gap-1.5 text-sm font-semibold">
+              <History className="size-4" />
+              変更履歴
+            </h2>
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              aria-label="履歴を再取得"
+              disabled={isLoading}
+              onClick={onRefresh}
+            >
+              <RefreshCw
+                className={cn('size-3', isLoading && 'animate-spin')}
+              />
+            </Button>
+          </div>
+          <SaveForm isSaving={isSaving} onSave={onSave} />
+          {notice !== null && (
+            <NoticeBanner message={notice} onDismiss={onDismissNotice} />
+          )}
+          {undoBackupCommitId !== null && (
+            <UndoBanner
+              backupCommitId={undoBackupCommitId}
+              isRestoring={isRestoring}
+              onUndoRestore={onUndoRestore}
+              onDismiss={onDismissUndo}
+            />
+          )}
+        </div>
+
+        {/* タイムライン */}
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="space-y-3 p-2">
+            {hasUncommittedChanges && (
+              <button
+                type="button"
+                aria-current={isUncommittedSelected}
+                className={cn(
+                  'w-full rounded-md border border-dashed px-2.5 py-2 text-left transition-colors',
+                  isUncommittedSelected
+                    ? 'border-primary bg-accent'
+                    : 'hover:bg-accent/50',
+                )}
+                onClick={onSelectUncommitted}
+              >
+                <p className="text-xs font-medium">未コミットの変更</p>
+                <p className="mt-0.5 text-[10px] text-muted-foreground">
+                  まだ保存されていない編集内容
+                </p>
+              </button>
+            )}
+
+            {isLoading && commits.length === 0 && (
+              <p className="animate-pulse py-8 text-center text-sm text-muted-foreground">
+                履歴を読み込んでいます…
+              </p>
+            )}
+
+            {!isLoading && commits.length === 0 && (
+              <p className="py-8 text-center text-sm text-muted-foreground">
+                まだ履歴がありません。メッセージを付けて保存すると履歴に残ります。
+              </p>
+            )}
+
+            {groups.map((group) => (
+              <div key={group.key} className="space-y-1.5">
+                <p className="px-0.5 text-[10px] font-medium text-muted-foreground">
+                  {formatDateHeading(group.key)}
+                </p>
+                {group.items.map((commit) => (
+                  <CommitRow
+                    key={commit.id}
+                    commit={commit}
+                    isSelected={commit.id === selectedCommitId}
+                    isRestoring={isRestoring}
+                    onSelect={() => onSelectCommit?.(commit.id)}
+                    onRequestRestore={() => setRestoreTarget(commit)}
+                  />
+                ))}
+              </div>
+            ))}
+
+            {hasMore && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                disabled={isLoadingMore}
+                onClick={onLoadMore}
+              >
+                {isLoadingMore ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : null}
+                さらに読み込む
+              </Button>
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+
+      {/* 差分ビュー */}
+      <div className="min-h-0 min-w-0 flex-1">{detail}</div>
+
+      {/* 復元の確認（破壊的操作） */}
+      <Dialog
+        open={restoreTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setRestoreTarget(null);
+        }}
+      >
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>この状態に戻しますか？</DialogTitle>
+            <DialogDescription>
+              「{restoreTarget?.message}
+              」の時点にプロジェクト全体を戻します。この時点に存在しないノード・執筆指示・用語は削除されます。
+              復元前の状態はバックアップとして自動保存されるため、あとから元に戻せます。
+              なお、AIの編集保護設定は復元の対象外で、現在の設定が維持されます。
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRestoreTarget(null)}>
+              キャンセル
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={isRestoring}
+              onClick={handleConfirmRestore}
+            >
+              {isRestoring ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <RotateCcw className="size-4" />
+              )}
+              復元する
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/packages/ui/src/components/features/version-history/commit-timeline.tsx
+++ b/packages/ui/src/components/features/version-history/commit-timeline.tsx
@@ -32,6 +32,7 @@ import {
   formatDateHeading,
   formatTimeOfDay,
 } from './version-badges';
+import { LoadErrorState } from './load-error-state';
 
 /** タイムラインに並べるコミット */
 export interface CommitTimelineItem {
@@ -57,6 +58,13 @@ export interface CommitTimelineProps {
   isUncommittedSelected?: boolean;
   isLoading?: boolean;
   isLoadingMore?: boolean;
+  /** 再取得中か（初回読み込み後の再検証） */
+  isRefreshing?: boolean;
+  /**
+   * 履歴の取得に失敗したか。
+   * 「履歴がない」と区別できるよう、空表示ではなくエラー表示にする。
+   */
+  hasError?: boolean;
   /** 次ページがあるか（next_cursor !== null） */
   hasMore?: boolean;
   isSaving?: boolean;
@@ -279,6 +287,8 @@ export function CommitTimeline({
   isUncommittedSelected = false,
   isLoading = false,
   isLoadingMore = false,
+  isRefreshing = false,
+  hasError = false,
   hasMore = false,
   isSaving = false,
   isRestoring = false,
@@ -325,11 +335,14 @@ export function CommitTimeline({
               size="icon-xs"
               variant="ghost"
               aria-label="履歴を再取得"
-              disabled={isLoading}
+              disabled={isLoading || isRefreshing}
               onClick={onRefresh}
             >
               <RefreshCw
-                className={cn('size-3', isLoading && 'animate-spin')}
+                className={cn(
+                  'size-3',
+                  (isLoading || isRefreshing) && 'animate-spin',
+                )}
               />
             </Button>
           </div>
@@ -375,7 +388,15 @@ export function CommitTimeline({
               </p>
             )}
 
-            {!isLoading && commits.length === 0 && (
+            {/* 取得失敗を「履歴がない」と誤解させない（復元を伴う画面なので特に重要） */}
+            {!isLoading && hasError && commits.length === 0 && (
+              <LoadErrorState
+                message="履歴を読み込めませんでした。"
+                onRetry={onRefresh}
+              />
+            )}
+
+            {!isLoading && !hasError && commits.length === 0 && (
               <p className="py-8 text-center text-sm text-muted-foreground">
                 まだ履歴がありません。メッセージを付けて保存すると履歴に残ります。
               </p>

--- a/packages/ui/src/components/features/version-history/index.ts
+++ b/packages/ui/src/components/features/version-history/index.ts
@@ -1,0 +1,4 @@
+export * from './version-badges';
+export * from './commit-diff-view';
+export * from './commit-timeline';
+export * from './node-revision-panel';

--- a/packages/ui/src/components/features/version-history/index.ts
+++ b/packages/ui/src/components/features/version-history/index.ts
@@ -1,4 +1,5 @@
 export * from './version-badges';
+export * from './load-error-state';
 export * from './commit-diff-view';
 export * from './commit-timeline';
 export * from './node-revision-panel';

--- a/packages/ui/src/components/features/version-history/load-error-state.tsx
+++ b/packages/ui/src/components/features/version-history/load-error-state.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+
+export interface LoadErrorStateProps {
+  message: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+/**
+ * 読み込みに失敗したことを示す表示。
+ *
+ * 履歴や差分の取得に失敗したとき、空状態（「履歴がありません」等）を出すと
+ * 「データが存在しない」と誤解させてしまう。特に復元のような破壊的操作を
+ * 伴う画面では危険なため、失敗は失敗として見せて再試行の導線を出す。
+ */
+export function LoadErrorState({
+  message,
+  onRetry,
+  className,
+}: LoadErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'flex flex-col items-center gap-2 px-3 py-8 text-center',
+        className,
+      )}
+    >
+      <AlertTriangle className="size-5 text-destructive" />
+      <p className="text-sm text-muted-foreground">{message}</p>
+      {onRetry && (
+        <Button size="xs" variant="outline" onClick={onRetry}>
+          <RefreshCw className="size-3" />
+          再試行
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/features/version-history/mock-data.ts
+++ b/packages/ui/src/components/features/version-history/mock-data.ts
@@ -1,0 +1,152 @@
+import type { CommitTimelineItem } from './commit-timeline';
+import type { CommitDiffEntryItem } from './commit-diff-view';
+import type { NodeRevisionItem } from './node-revision-panel';
+
+/**
+ * Story 用のモックデータ。
+ * packages/ui は adapter に依存しないため、ここで直接定義する。
+ */
+export const mockCommits: CommitTimelineItem[] = [
+  {
+    id: 'commit_5',
+    message: '自動保存',
+    commitType: 'auto',
+    addedCount: 0,
+    modifiedCount: 1,
+    removedCount: 0,
+    createdAt: new Date('2026-08-04T18:42:00'),
+  },
+  {
+    id: 'commit_4',
+    message: '第二章の視点を三人称に統一した',
+    commitType: 'manual',
+    addedCount: 0,
+    modifiedCount: 3,
+    removedCount: 1,
+    createdAt: new Date('2026-08-04T16:05:00'),
+  },
+  {
+    id: 'commit_3',
+    message: '「第一章 雨の帰り道」の時点に復元',
+    commitType: 'restore',
+    addedCount: 1,
+    modifiedCount: 2,
+    removedCount: 0,
+    createdAt: new Date('2026-08-04T11:20:00'),
+  },
+  {
+    id: 'commit_2',
+    message: '復元前の自動バックアップ',
+    commitType: 'backup',
+    addedCount: 0,
+    modifiedCount: 2,
+    removedCount: 0,
+    createdAt: new Date('2026-08-04T11:19:00'),
+  },
+  {
+    id: 'commit_1',
+    message: '第一章 雨の帰り道',
+    commitType: 'manual',
+    addedCount: 4,
+    modifiedCount: 0,
+    removedCount: 0,
+    createdAt: new Date('2026-08-03T22:10:00'),
+  },
+];
+
+export const mockDiffEntries: CommitDiffEntryItem[] = [
+  {
+    entryType: 'node',
+    targetId: 'node_writing_1',
+    changeType: 'modified',
+    name: '第二章 図書室の午後',
+    nodeType: 'writing',
+    fieldChanges: [
+      { field: 'name', oldValue: '第二章 図書室', newValue: '第二章 図書室の午後' },
+      { field: 'canon_status', oldValue: 'draft', newValue: 'confirmed' },
+    ],
+    textDiffs: [
+      {
+        field: 'content',
+        lines: [
+          { op: 'eq', text: '　窓の外では、まだ雨が降り続いていた。' },
+          { op: 'eq', text: '' },
+          { op: 'del', text: '　私は本棚の前で立ち止まった。' },
+          { op: 'add', text: '　彼女は本棚の前で立ち止まった。' },
+          { op: 'add', text: '　背表紙をなぞる指が、一冊のところで止まる。' },
+          { op: 'eq', text: '' },
+          { op: 'eq', text: '「これ、まだ返してなかったんだ」' },
+          { op: 'eq', text: '' },
+          { op: 'eq', text: '　声が思ったより大きく響いて、慌てて口をつぐんだ。' },
+          { op: 'eq', text: '　図書室には誰もいないはずだった。' },
+          { op: 'eq', text: '' },
+          { op: 'eq', text: '　けれど、奥の閲覧席から椅子を引く音がした。' },
+          { op: 'del', text: '　私は息を止めた。' },
+          { op: 'add', text: '　彼女は息を止めた。' },
+        ],
+      },
+    ],
+  },
+  {
+    entryType: 'node',
+    targetId: 'node_memo_9',
+    changeType: 'added',
+    name: '伏線メモ: 図書室の鍵',
+    nodeType: 'memo',
+    fieldChanges: [],
+    textDiffs: [],
+  },
+  {
+    entryType: 'glossary_term',
+    targetId: 'term_3',
+    changeType: 'removed',
+    name: '旧校舎',
+    nodeType: null,
+    fieldChanges: [],
+    textDiffs: [],
+  },
+  {
+    entryType: 'instruction',
+    targetId: 'instruction_1',
+    changeType: 'modified',
+    name: '文体の指示',
+    nodeType: null,
+    fieldChanges: [
+      { field: 'enabled', oldValue: 'false', newValue: 'true' },
+    ],
+    textDiffs: [
+      {
+        field: 'content',
+        lines: [
+          { op: 'del', text: '一人称視点で書く。' },
+          { op: 'add', text: '三人称一元視点で書く。' },
+          { op: 'eq', text: '地の文は常体、会話文は口語で。' },
+        ],
+      },
+    ],
+  },
+];
+
+export const mockNodeRevisions: NodeRevisionItem[] = [
+  {
+    commitId: 'commit_5',
+    message: '自動保存',
+    commitType: 'auto',
+    createdAt: new Date('2026-08-04T18:42:00'),
+    changeType: 'modified',
+  },
+  {
+    commitId: 'commit_4',
+    message: '第二章の視点を三人称に統一した',
+    commitType: 'manual',
+    createdAt: new Date('2026-08-04T16:05:00'),
+    changeType: 'modified',
+  },
+  {
+    commitId: 'commit_1',
+    message: '第一章 雨の帰り道',
+    commitType: 'manual',
+    createdAt: new Date('2026-08-03T22:10:00'),
+    changeType: 'added',
+  },
+];

--- a/packages/ui/src/components/features/version-history/node-revision-panel.stories.tsx
+++ b/packages/ui/src/components/features/version-history/node-revision-panel.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import * as React from 'react';
+import { NodeRevisionPanel } from './node-revision-panel';
+import { CommitDiffView } from './commit-diff-view';
+import { mockDiffEntries, mockNodeRevisions } from './mock-data';
+
+const meta = {
+  title: 'Features/NodeRevisionPanel',
+  component: NodeRevisionPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ height: '600px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof NodeRevisionPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    revisions: mockNodeRevisions,
+    selectedCommitId: 'commit_4',
+    detail: (
+      <CommitDiffView
+        entries={mockDiffEntries.slice(0, 1)}
+        title="第二章の視点を三人称に統一した"
+        subtitle="このノードの差分"
+      />
+    ),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    revisions: [],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    revisions: [],
+    isLoading: true,
+  },
+};
+
+export const Interactive: StoryObj = {
+  render: () => {
+    const [selectedCommitId, setSelectedCommitId] = React.useState<
+      string | null
+    >(null);
+    const [notice, setNotice] = React.useState<string | null>(null);
+
+    const selected = mockNodeRevisions.find(
+      (revision) => revision.commitId === selectedCommitId,
+    );
+
+    return (
+      <NodeRevisionPanel
+        revisions={mockNodeRevisions}
+        selectedCommitId={selectedCommitId}
+        notice={notice}
+        onDismissNotice={() => setNotice(null)}
+        onSelect={setSelectedCommitId}
+        onRestore={(commitId) => {
+          const target = mockNodeRevisions.find(
+            (revision) => revision.commitId === commitId,
+          );
+          setNotice(`「${target?.message ?? ''}」の時点の本文に戻しました。`);
+        }}
+        detail={
+          selected ? (
+            <CommitDiffView
+              entries={mockDiffEntries.slice(0, 1)}
+              title={selected.message}
+              subtitle="このノードの差分"
+            />
+          ) : (
+            <CommitDiffView
+              entries={[]}
+              emptyMessage="履歴を選ぶと、その時点の差分が表示されます。"
+            />
+          )
+        }
+      />
+    );
+  },
+};

--- a/packages/ui/src/components/features/version-history/node-revision-panel.stories.tsx
+++ b/packages/ui/src/components/features/version-history/node-revision-panel.stories.tsx
@@ -48,6 +48,13 @@ export const Loading: Story = {
   },
 };
 
+export const LoadFailed: Story = {
+  args: {
+    revisions: [],
+    hasError: true,
+  },
+};
+
 export const Interactive: StoryObj = {
   render: () => {
     const [selectedCommitId, setSelectedCommitId] = React.useState<

--- a/packages/ui/src/components/features/version-history/node-revision-panel.tsx
+++ b/packages/ui/src/components/features/version-history/node-revision-panel.tsx
@@ -18,6 +18,7 @@ import {
   formatDateHeading,
 } from './version-badges';
 import { groupByDay } from '@/lib/version-history-utils';
+import { LoadErrorState } from './load-error-state';
 
 /** ノードを変更したコミット 1 件 */
 export interface NodeRevisionItem {
@@ -34,6 +35,13 @@ export interface NodeRevisionPanelProps {
   selectedCommitId?: string | null;
   isLoading?: boolean;
   isLoadingMore?: boolean;
+  /** 再取得中か（初回読み込み後の再検証） */
+  isRefreshing?: boolean;
+  /**
+   * 履歴の取得に失敗したか。
+   * 「履歴がない」と区別できるよう、空表示ではなくエラー表示にする。
+   */
+  hasError?: boolean;
   /** 次ページがあるか（next_cursor !== null） */
   hasMore?: boolean;
   isRestoring?: boolean;
@@ -121,6 +129,8 @@ export function NodeRevisionPanel({
   selectedCommitId = null,
   isLoading = false,
   isLoadingMore = false,
+  isRefreshing = false,
+  hasError = false,
   hasMore = false,
   isRestoring = false,
   notice = null,
@@ -160,11 +170,14 @@ export function NodeRevisionPanel({
               size="icon-xs"
               variant="ghost"
               aria-label="履歴を再取得"
-              disabled={isLoading}
+              disabled={isLoading || isRefreshing}
               onClick={onRefresh}
             >
               <RefreshCw
-                className={cn('size-3', isLoading && 'animate-spin')}
+                className={cn(
+                  'size-3',
+                  (isLoading || isRefreshing) && 'animate-spin',
+                )}
               />
             </Button>
           </div>
@@ -198,7 +211,15 @@ export function NodeRevisionPanel({
               </p>
             )}
 
-            {!isLoading && revisions.length === 0 && (
+            {/* 取得失敗を「履歴がない」と誤解させない */}
+            {!isLoading && hasError && revisions.length === 0 && (
+              <LoadErrorState
+                message="履歴を読み込めませんでした。"
+                onRetry={onRefresh}
+              />
+            )}
+
+            {!isLoading && !hasError && revisions.length === 0 && (
               <p className="py-8 text-center text-sm text-muted-foreground">
                 このノードの履歴はまだありません。
               </p>

--- a/packages/ui/src/components/features/version-history/node-revision-panel.tsx
+++ b/packages/ui/src/components/features/version-history/node-revision-panel.tsx
@@ -1,0 +1,276 @@
+import * as React from 'react';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+import { History, Loader2, RefreshCw, RotateCcw, X } from 'lucide-react';
+import type { CommitTypeValue } from '@/lib/version-history-utils';
+import {
+  CommitTypeBadge,
+  formatTimeOfDay,
+  formatDateHeading,
+} from './version-badges';
+import { groupByDay } from '@/lib/version-history-utils';
+
+/** ノードを変更したコミット 1 件 */
+export interface NodeRevisionItem {
+  commitId: string;
+  message: string;
+  commitType: CommitTypeValue;
+  createdAt: Date;
+  changeType: 'added' | 'modified';
+}
+
+export interface NodeRevisionPanelProps {
+  revisions: NodeRevisionItem[];
+  /** 選択中のコミットID */
+  selectedCommitId?: string | null;
+  isLoading?: boolean;
+  isLoadingMore?: boolean;
+  /** 次ページがあるか（next_cursor !== null） */
+  hasMore?: boolean;
+  isRestoring?: boolean;
+  /** 穏当に見せる通知 */
+  notice?: string | null;
+  onDismissNotice?: () => void;
+  onSelect?: (commitId: string) => void;
+  onRestore?: (commitId: string) => void;
+  onLoadMore?: () => void;
+  onRefresh?: () => void;
+  /** 右側に並べる差分ビュー */
+  detail?: React.ReactNode;
+  className?: string;
+}
+
+const CHANGE_TYPE_LABELS: Record<NodeRevisionItem['changeType'], string> = {
+  added: '作成',
+  modified: '変更',
+};
+
+function RevisionRow({
+  revision,
+  isSelected,
+  isRestoring,
+  onSelect,
+  onRequestRestore,
+}: {
+  revision: NodeRevisionItem;
+  isSelected: boolean;
+  isRestoring: boolean;
+  onSelect?: () => void;
+  onRequestRestore?: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'group/revision rounded-md border px-2.5 py-2 transition-colors',
+        isSelected ? 'border-primary bg-accent' : 'hover:bg-accent/50',
+      )}
+    >
+      <button
+        type="button"
+        className="w-full text-left"
+        aria-current={isSelected}
+        onClick={onSelect}
+      >
+        <div className="flex items-center gap-2">
+          <CommitTypeBadge commitType={revision.commitType} />
+          <span className="shrink-0 text-[10px] text-muted-foreground">
+            {CHANGE_TYPE_LABELS[revision.changeType]}
+          </span>
+          <span className="ml-auto shrink-0 font-mono text-[10px] text-muted-foreground">
+            {formatTimeOfDay(revision.createdAt)}
+          </span>
+        </div>
+        <p className="mt-1 line-clamp-2 text-xs font-medium">
+          {revision.message}
+        </p>
+      </button>
+      <div className="mt-1 flex justify-end">
+        <Button
+          size="xs"
+          variant="ghost"
+          className="opacity-0 transition-opacity group-hover/revision:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100"
+          disabled={isRestoring}
+          onClick={onRequestRestore}
+        >
+          <RotateCcw className="size-3" />
+          本文を戻す
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * ノード単位の変更履歴パネル（エディタのサイドパネル用）。
+ *
+ * 復元は本文のみが対象で、名前・親・並び順・正典ステータス・AIコンテキスト設定は変わらない。
+ * フォルダノードでは呼べないため、呼び出し側でマウントを制御すること。
+ * 表示専用コンポーネント（データ取得は行わない）。
+ */
+export function NodeRevisionPanel({
+  revisions,
+  selectedCommitId = null,
+  isLoading = false,
+  isLoadingMore = false,
+  hasMore = false,
+  isRestoring = false,
+  notice = null,
+  onDismissNotice,
+  onSelect,
+  onRestore,
+  onLoadMore,
+  onRefresh,
+  detail,
+  className,
+}: NodeRevisionPanelProps) {
+  const [restoreTarget, setRestoreTarget] =
+    React.useState<NodeRevisionItem | null>(null);
+
+  const groups = React.useMemo(
+    () => groupByDay(revisions, (revision) => revision.createdAt),
+    [revisions],
+  );
+
+  const handleConfirmRestore = () => {
+    if (restoreTarget === null) return;
+    onRestore?.(restoreTarget.commitId);
+    setRestoreTarget(null);
+  };
+
+  return (
+    <div className={cn('flex h-full min-h-0 flex-col md:flex-row', className)}>
+      {/* 狭い画面では縦積み、md 以上で左カラム固定の2カラム */}
+      <div className="flex max-h-72 min-w-0 flex-col border-b md:h-full md:max-h-none md:w-64 md:shrink-0 md:border-b-0 md:border-r">
+        <div className="shrink-0 space-y-2 border-b px-3 py-2">
+          <div className="flex items-center justify-between">
+            <h2 className="flex items-center gap-1.5 text-sm font-semibold">
+              <History className="size-4" />
+              このノードの履歴
+            </h2>
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              aria-label="履歴を再取得"
+              disabled={isLoading}
+              onClick={onRefresh}
+            >
+              <RefreshCw
+                className={cn('size-3', isLoading && 'animate-spin')}
+              />
+            </Button>
+          </div>
+          {notice !== null && (
+            <div
+              role="status"
+              className="flex items-start gap-2 rounded-md bg-muted px-2.5 py-2"
+            >
+              <p className="min-w-0 flex-1 text-xs text-muted-foreground">
+                {notice}
+              </p>
+              {onDismissNotice && (
+                <Button
+                  size="icon-xs"
+                  variant="ghost"
+                  aria-label="通知を閉じる"
+                  onClick={onDismissNotice}
+                >
+                  <X className="size-3" />
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="space-y-3 p-2">
+            {isLoading && revisions.length === 0 && (
+              <p className="animate-pulse py-8 text-center text-sm text-muted-foreground">
+                履歴を読み込んでいます…
+              </p>
+            )}
+
+            {!isLoading && revisions.length === 0 && (
+              <p className="py-8 text-center text-sm text-muted-foreground">
+                このノードの履歴はまだありません。
+              </p>
+            )}
+
+            {groups.map((group) => (
+              <div key={group.key} className="space-y-1.5">
+                <p className="px-0.5 text-[10px] font-medium text-muted-foreground">
+                  {formatDateHeading(group.key)}
+                </p>
+                {group.items.map((revision) => (
+                  <RevisionRow
+                    key={revision.commitId}
+                    revision={revision}
+                    isSelected={revision.commitId === selectedCommitId}
+                    isRestoring={isRestoring}
+                    onSelect={() => onSelect?.(revision.commitId)}
+                    onRequestRestore={() => setRestoreTarget(revision)}
+                  />
+                ))}
+              </div>
+            ))}
+
+            {hasMore && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                disabled={isLoadingMore}
+                onClick={onLoadMore}
+              >
+                {isLoadingMore ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : null}
+                さらに読み込む
+              </Button>
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+
+      <div className="min-h-0 min-w-0 flex-1">{detail}</div>
+
+      <Dialog
+        open={restoreTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setRestoreTarget(null);
+        }}
+      >
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>本文をこの時点に戻しますか？</DialogTitle>
+            <DialogDescription>
+              「{restoreTarget?.message}」の時点の本文に戻します。
+              戻るのは本文だけで、名前・置き場所・並び順・正典ステータス・AIコンテキスト設定は変わりません。
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRestoreTarget(null)}>
+              キャンセル
+            </Button>
+            <Button disabled={isRestoring} onClick={handleConfirmRestore}>
+              {isRestoring ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <RotateCcw className="size-4" />
+              )}
+              本文を戻す
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/packages/ui/src/components/features/version-history/version-badges.tsx
+++ b/packages/ui/src/components/features/version-history/version-badges.tsx
@@ -1,0 +1,212 @@
+import { cn } from '@/lib/utils';
+import type {
+  CommitTypeValue,
+  DiffChangeTypeValue,
+  RevisionEntryTypeValue,
+} from '@/lib/version-history-utils';
+
+/** コミット種別ごとの見た目とラベル */
+export const COMMIT_TYPE_META: Record<
+  CommitTypeValue,
+  { label: string; className: string }
+> = {
+  manual: {
+    label: '保存',
+    className:
+      'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+  },
+  auto: {
+    label: '自動保存',
+    className: 'bg-muted text-muted-foreground',
+  },
+  backup: {
+    label: 'バックアップ',
+    className:
+      'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
+  },
+  restore: {
+    label: '復元',
+    className:
+      'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
+  },
+};
+
+/**
+ * コミット種別のバッジ（保存 / 自動保存 / バックアップ / 復元）
+ */
+export function CommitTypeBadge({
+  commitType,
+  className,
+}: {
+  commitType: CommitTypeValue;
+  className?: string;
+}) {
+  const meta = COMMIT_TYPE_META[commitType];
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-xs font-medium',
+        meta.className,
+        className,
+      )}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+/** 差分の変更種別ごとの見た目とラベル */
+export const CHANGE_TYPE_META: Record<
+  DiffChangeTypeValue,
+  { label: string; symbol: string; className: string }
+> = {
+  added: {
+    label: '追加',
+    symbol: '+',
+    className:
+      'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+  },
+  modified: {
+    label: '変更',
+    symbol: '~',
+    className:
+      'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
+  },
+  removed: {
+    label: '削除',
+    symbol: '−',
+    className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+  },
+};
+
+/**
+ * 差分エントリの変更種別バッジ（追加 / 変更 / 削除）
+ */
+export function ChangeTypeBadge({
+  changeType,
+  className,
+}: {
+  changeType: DiffChangeTypeValue;
+  className?: string;
+}) {
+  const meta = CHANGE_TYPE_META[changeType];
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center gap-0.5 rounded px-1.5 py-0.5 text-xs font-medium',
+        meta.className,
+        className,
+      )}
+    >
+      <span aria-hidden className="font-mono">
+        {meta.symbol}
+      </span>
+      {meta.label}
+    </span>
+  );
+}
+
+/** 差分エントリの対象種別ラベル */
+export const ENTRY_TYPE_LABELS: Record<RevisionEntryTypeValue, string> = {
+  project: 'プロジェクト',
+  node: 'ノード',
+  instruction: '執筆指示',
+  glossary_term: '用語',
+};
+
+/** ノード種別ラベル */
+export const NODE_TYPE_LABELS: Record<string, string> = {
+  folder: 'フォルダ',
+  plot: 'プロット',
+  character: 'キャラクター',
+  memo: 'メモ',
+  writing: '執筆',
+};
+
+/**
+ * 差分エントリの見出しに出す種別ラベル。
+ * ノードの場合はノード種別（執筆 / プロット等）を優先して表示する。
+ */
+export function entryKindLabel(
+  entryType: RevisionEntryTypeValue,
+  nodeType: string | null,
+): string {
+  if (entryType === 'node' && nodeType !== null) {
+    return NODE_TYPE_LABELS[nodeType] ?? nodeType;
+  }
+  return ENTRY_TYPE_LABELS[entryType];
+}
+
+/**
+ * 差分に現れるフィールド名の表示ラベル。
+ * バックエンドは snake_case で返すが、表記揺れに備えて camelCase も引けるようにしている。
+ */
+export const DIFF_FIELD_LABELS: Record<string, string> = {
+  name: '名前',
+  content: '本文',
+  synopsis: 'あらすじ',
+  setting: '舞台設定',
+  theme: 'テーマ',
+  structure: '構成',
+  conflict: '対立・葛藤',
+  resolution: '結末',
+  notes: '備考',
+  aliases: '別名',
+  role: '役職',
+  gender: '性別',
+  age: '年齢',
+  appearance: '外見',
+  personality: '性格',
+  background: '経歴',
+  motivation: '動機',
+  relationships: '人間関係',
+  tags: 'タグ',
+  goal: '目標',
+  reading: '読み',
+  term: '用語',
+  title: 'タイトル',
+  enabled: '有効',
+  order: '表示順',
+  parent_id: '親ノード',
+  parentId: '親ノード',
+  node_type: '種別',
+  nodeType: '種別',
+  word_count: '文字数',
+  wordCount: '文字数',
+  canon_status: '正典ステータス',
+  canonStatus: '正典ステータス',
+  context_policy: 'AIコンテキスト',
+  contextPolicy: 'AIコンテキスト',
+  target_audience: '想定読者',
+  targetAudience: '想定読者',
+  target_word_count: '目標文字数',
+  targetWordCount: '目標文字数',
+};
+
+/**
+ * フィールド名を日本語ラベルに変換する（未知のフィールドはそのまま返す）
+ */
+export function fieldLabel(field: string): string {
+  return DIFF_FIELD_LABELS[field] ?? field;
+}
+
+/**
+ * `YYYY-MM-DD` を「2026年8月4日」形式の見出しにする。
+ * ロケール API を使わないためタイムゾーンに依存しない。
+ */
+export function formatDateHeading(dateKey: string): string {
+  const [year, month, day] = dateKey.split('-');
+  if (year === undefined || month === undefined || day === undefined) {
+    return dateKey;
+  }
+  return `${year}年${Number(month)}月${Number(day)}日`;
+}
+
+/**
+ * 時刻（HH:MM）だけを表示する
+ */
+export function formatTimeOfDay(date: Date): string {
+  const hours = `${date.getHours()}`.padStart(2, '0');
+  const minutes = `${date.getMinutes()}`.padStart(2, '0');
+  return `${hours}:${minutes}`;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,5 +3,6 @@ import './index.css';
 export * from './lib/utils';
 export * from './lib/keyboard-utils';
 export * from './lib/writing-format';
+export * from './lib/version-history-utils';
 export * from './components';
 export * from './icons';

--- a/packages/ui/src/lib/version-history-utils.spec.ts
+++ b/packages/ui/src/lib/version-history-utils.spec.ts
@@ -1,0 +1,257 @@
+import {
+  buildDiffRows,
+  COMMIT_MESSAGE_MAX_LENGTH,
+  countDiffLineOps,
+  formatChangeCounts,
+  groupByDay,
+  toLocalDateKey,
+  totalChangeCount,
+  validateCommitMessage,
+  type DiffLineInput,
+  type DiffRow,
+} from '@/lib/version-history-utils';
+
+describe('validateCommitMessage', () => {
+  it('1文字以上ならエラーにならない', () => {
+    expect(validateCommitMessage('a')).toBeNull();
+    expect(validateCommitMessage('第一章を書き上げた')).toBeNull();
+  });
+
+  it('空文字・空白のみはエラー', () => {
+    expect(validateCommitMessage('')).toBe('メッセージを入力してください');
+    expect(validateCommitMessage('   \n\t ')).toBe(
+      'メッセージを入力してください',
+    );
+  });
+
+  it('上限文字数ちょうどは許可する', () => {
+    expect(validateCommitMessage('あ'.repeat(COMMIT_MESSAGE_MAX_LENGTH))).toBe(
+      null,
+    );
+  });
+
+  it('上限を超えるとエラー', () => {
+    expect(
+      validateCommitMessage('あ'.repeat(COMMIT_MESSAGE_MAX_LENGTH + 1)),
+    ).toBe('メッセージは500文字以内で入力してください');
+  });
+
+  it('前後の空白は文字数に含めない', () => {
+    const message = `  ${'あ'.repeat(COMMIT_MESSAGE_MAX_LENGTH)}  `;
+    expect(validateCommitMessage(message)).toBeNull();
+  });
+});
+
+describe('totalChangeCount', () => {
+  it('3種類の件数を合計する', () => {
+    expect(totalChangeCount({ added: 2, modified: 1, removed: 3 })).toBe(6);
+    expect(totalChangeCount({ added: 0, modified: 0, removed: 0 })).toBe(0);
+  });
+});
+
+describe('formatChangeCounts', () => {
+  it('0件の種別を省略する', () => {
+    expect(formatChangeCounts({ added: 2, modified: 1, removed: 0 })).toBe(
+      '追加 2件・変更 1件',
+    );
+    expect(formatChangeCounts({ added: 0, modified: 0, removed: 5 })).toBe(
+      '削除 5件',
+    );
+  });
+
+  it('全種別を表示する', () => {
+    expect(formatChangeCounts({ added: 1, modified: 2, removed: 3 })).toBe(
+      '追加 1件・変更 2件・削除 3件',
+    );
+  });
+
+  it('すべて0件なら「変更なし」', () => {
+    expect(formatChangeCounts({ added: 0, modified: 0, removed: 0 })).toBe(
+      '変更なし',
+    );
+  });
+});
+
+describe('countDiffLineOps', () => {
+  it('追加行と削除行を数える', () => {
+    const lines: DiffLineInput[] = [
+      { op: 'eq', text: 'a' },
+      { op: 'del', text: 'b' },
+      { op: 'add', text: 'c' },
+      { op: 'add', text: 'd' },
+    ];
+    expect(countDiffLineOps(lines)).toEqual({ added: 2, removed: 1 });
+  });
+
+  it('空配列なら 0 件', () => {
+    expect(countDiffLineOps([])).toEqual({ added: 0, removed: 0 });
+  });
+});
+
+describe('buildDiffRows', () => {
+  function lineRows(rows: DiffRow[]) {
+    return rows.filter((row) => row.kind === 'line');
+  }
+
+  it('行番号を eq / del / add の規則で振る', () => {
+    const rows = buildDiffRows([
+      { op: 'eq', text: 'A' },
+      { op: 'del', text: 'B' },
+      { op: 'add', text: 'B2' },
+      { op: 'eq', text: 'C' },
+    ]);
+    expect(lineRows(rows)).toEqual([
+      {
+        kind: 'line',
+        op: 'eq',
+        text: 'A',
+        oldLineNumber: 1,
+        newLineNumber: 1,
+      },
+      {
+        kind: 'line',
+        op: 'del',
+        text: 'B',
+        oldLineNumber: 2,
+        newLineNumber: null,
+      },
+      {
+        kind: 'line',
+        op: 'add',
+        text: 'B2',
+        oldLineNumber: null,
+        newLineNumber: 2,
+      },
+      {
+        kind: 'line',
+        op: 'eq',
+        text: 'C',
+        oldLineNumber: 3,
+        newLineNumber: 3,
+      },
+    ]);
+  });
+
+  it('変更行が無い場合は折りたたまず全行返す', () => {
+    const lines: DiffLineInput[] = Array.from({ length: 20 }, (_, i) => ({
+      op: 'eq' as const,
+      text: `line ${i}`,
+    }));
+    const rows = buildDiffRows(lines, 1);
+    expect(rows).toHaveLength(20);
+    expect(rows.every((row) => row.kind === 'line')).toBe(true);
+  });
+
+  it('変更箇所から離れた変更なし行を gap に折りたたむ', () => {
+    const lines: DiffLineInput[] = [
+      ...Array.from({ length: 10 }, (_, i) => ({
+        op: 'eq' as const,
+        text: `head ${i}`,
+      })),
+      { op: 'add', text: 'NEW' },
+      ...Array.from({ length: 10 }, (_, i) => ({
+        op: 'eq' as const,
+        text: `tail ${i}`,
+      })),
+    ];
+    const rows = buildDiffRows(lines, 2);
+
+    // 先頭 8 行 / 末尾 8 行が折りたたまれ、前後2行 + 変更行のみ残る
+    expect(rows[0]).toEqual({ kind: 'gap', hiddenCount: 8 });
+    expect(rows[rows.length - 1]).toEqual({ kind: 'gap', hiddenCount: 8 });
+    expect(lineRows(rows)).toHaveLength(5);
+  });
+
+  it('隣接する変更のコンテキストが重なる場合は gap を作らない', () => {
+    const lines: DiffLineInput[] = [
+      { op: 'add', text: 'x' },
+      { op: 'eq', text: '1' },
+      { op: 'eq', text: '2' },
+      { op: 'add', text: 'y' },
+    ];
+    const rows = buildDiffRows(lines, 2);
+    expect(rows.some((row) => row.kind === 'gap')).toBe(false);
+    expect(rows).toHaveLength(4);
+  });
+
+  it('contextLines が 0 なら変更行のみ残す', () => {
+    const rows = buildDiffRows(
+      [
+        { op: 'eq', text: 'a' },
+        { op: 'del', text: 'b' },
+        { op: 'eq', text: 'c' },
+      ],
+      0,
+    );
+    expect(rows).toEqual([
+      { kind: 'gap', hiddenCount: 1 },
+      {
+        kind: 'line',
+        op: 'del',
+        text: 'b',
+        oldLineNumber: 2,
+        newLineNumber: null,
+      },
+      { kind: 'gap', hiddenCount: 1 },
+    ]);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(buildDiffRows([])).toEqual([]);
+  });
+});
+
+describe('toLocalDateKey', () => {
+  it('ローカルタイムゾーンの YYYY-MM-DD を返す', () => {
+    // jest は TZ=Asia/Tokyo で実行される
+    expect(toLocalDateKey(new Date('2026-08-04T12:00:00+09:00'))).toBe(
+      '2026-08-04',
+    );
+  });
+
+  it('1桁の月日をゼロ埋めする', () => {
+    expect(toLocalDateKey(new Date('2026-01-02T10:00:00+09:00'))).toBe(
+      '2026-01-02',
+    );
+  });
+});
+
+describe('groupByDay', () => {
+  interface Item {
+    id: string;
+    createdAt: Date;
+  }
+  const getDate = (item: Item) => item.createdAt;
+
+  it('連続する同日の要素をまとめる', () => {
+    const items: Item[] = [
+      { id: 'c3', createdAt: new Date('2026-08-04T18:00:00+09:00') },
+      { id: 'c2', createdAt: new Date('2026-08-04T09:00:00+09:00') },
+      { id: 'c1', createdAt: new Date('2026-08-03T23:00:00+09:00') },
+    ];
+    const groups = groupByDay(items, getDate);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].key).toBe('2026-08-04');
+    expect(groups[0].items.map((i) => i.id)).toEqual(['c3', 'c2']);
+    expect(groups[1].key).toBe('2026-08-03');
+    expect(groups[1].items.map((i) => i.id)).toEqual(['c1']);
+  });
+
+  it('並べ替えず入力順を尊重する（非連続の同日は別グループ）', () => {
+    const items: Item[] = [
+      { id: 'a', createdAt: new Date('2026-08-04T10:00:00+09:00') },
+      { id: 'b', createdAt: new Date('2026-08-03T10:00:00+09:00') },
+      { id: 'c', createdAt: new Date('2026-08-04T11:00:00+09:00') },
+    ];
+    const groups = groupByDay(items, getDate);
+    expect(groups.map((g) => g.key)).toEqual([
+      '2026-08-04',
+      '2026-08-03',
+      '2026-08-04',
+    ]);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(groupByDay([], getDate)).toEqual([]);
+  });
+});

--- a/packages/ui/src/lib/version-history-utils.spec.ts
+++ b/packages/ui/src/lib/version-history-utils.spec.ts
@@ -5,7 +5,6 @@ import {
   formatChangeCounts,
   groupByDay,
   toLocalDateKey,
-  totalChangeCount,
   validateCommitMessage,
   type DiffLineInput,
   type DiffRow,
@@ -39,13 +38,6 @@ describe('validateCommitMessage', () => {
   it('前後の空白は文字数に含めない', () => {
     const message = `  ${'あ'.repeat(COMMIT_MESSAGE_MAX_LENGTH)}  `;
     expect(validateCommitMessage(message)).toBeNull();
-  });
-});
-
-describe('totalChangeCount', () => {
-  it('3種類の件数を合計する', () => {
-    expect(totalChangeCount({ added: 2, modified: 1, removed: 3 })).toBe(6);
-    expect(totalChangeCount({ added: 0, modified: 0, removed: 0 })).toBe(0);
   });
 });
 

--- a/packages/ui/src/lib/version-history-utils.ts
+++ b/packages/ui/src/lib/version-history-utils.ts
@@ -43,13 +43,6 @@ export interface ChangeCounts {
 }
 
 /**
- * 変更エントリ件数の合計
- */
-export function totalChangeCount(counts: ChangeCounts): number {
-  return counts.added + counts.modified + counts.removed;
-}
-
-/**
  * 変更エントリ件数を「追加 2件・変更 1件」のような表示文字列にする。
  * 0 件の種別は省略し、すべて 0 なら「変更なし」を返す。
  *

--- a/packages/ui/src/lib/version-history-utils.ts
+++ b/packages/ui/src/lib/version-history-utils.ts
@@ -1,0 +1,209 @@
+/**
+ * バージョン管理（コミット履歴 / 差分表示）用のピュアロジック。
+ * 表示コンポーネントから副作用のない計算を切り出したもの。
+ */
+
+/** コミット種別 */
+export type CommitTypeValue = 'manual' | 'auto' | 'backup' | 'restore';
+
+/** 差分エントリの変更種別 */
+export type DiffChangeTypeValue = 'added' | 'removed' | 'modified';
+
+/** 行差分の操作種別 */
+export type DiffLineOpValue = 'eq' | 'add' | 'del';
+
+/** 差分エントリの対象種別 */
+export type RevisionEntryTypeValue =
+  | 'project'
+  | 'node'
+  | 'instruction'
+  | 'glossary_term';
+
+/** コミットメッセージの最大文字数（バックエンド仕様） */
+export const COMMIT_MESSAGE_MAX_LENGTH = 500;
+
+/**
+ * コミットメッセージを検証する。
+ * @returns エラーメッセージ。問題なければ null
+ */
+export function validateCommitMessage(message: string): string | null {
+  const trimmed = message.trim();
+  if (trimmed.length === 0) return 'メッセージを入力してください';
+  if (trimmed.length > COMMIT_MESSAGE_MAX_LENGTH) {
+    return `メッセージは${COMMIT_MESSAGE_MAX_LENGTH}文字以内で入力してください`;
+  }
+  return null;
+}
+
+/** 変更エントリの件数（文字数や行数ではない） */
+export interface ChangeCounts {
+  added: number;
+  modified: number;
+  removed: number;
+}
+
+/**
+ * 変更エントリ件数の合計
+ */
+export function totalChangeCount(counts: ChangeCounts): number {
+  return counts.added + counts.modified + counts.removed;
+}
+
+/**
+ * 変更エントリ件数を「追加 2件・変更 1件」のような表示文字列にする。
+ * 0 件の種別は省略し、すべて 0 なら「変更なし」を返す。
+ *
+ * 件数はエントリ（変更対象）の数であり、文字数や行数ではない。
+ */
+export function formatChangeCounts(counts: ChangeCounts): string {
+  const parts: string[] = [];
+  if (counts.added > 0) parts.push(`追加 ${counts.added}件`);
+  if (counts.modified > 0) parts.push(`変更 ${counts.modified}件`);
+  if (counts.removed > 0) parts.push(`削除 ${counts.removed}件`);
+  return parts.length === 0 ? '変更なし' : parts.join('・');
+}
+
+/** 行差分の入力（op と本文のみ） */
+export interface DiffLineInput {
+  op: DiffLineOpValue;
+  text: string;
+}
+
+/**
+ * 差分ビューに描画する 1 行。
+ * `gap` は変更箇所から離れた変更なし行を折りたたんだプレースホルダ。
+ */
+export type DiffRow =
+  | {
+      kind: 'line';
+      op: DiffLineOpValue;
+      text: string;
+      /** 変更前の行番号（追加行は null） */
+      oldLineNumber: number | null;
+      /** 変更後の行番号（削除行は null） */
+      newLineNumber: number | null;
+    }
+  | { kind: 'gap'; hiddenCount: number };
+
+/**
+ * 行差分に行番号を振り、変更箇所から離れた変更なし行を折りたたむ。
+ *
+ * 変更行が 1 つも無い場合は折りたたまず全行を返す。
+ *
+ * @param lines - バックエンドが計算済みの行差分
+ * @param contextLines - 変更行の前後に残す変更なし行の数
+ */
+export function buildDiffRows(
+  lines: readonly DiffLineInput[],
+  contextLines = 3,
+): DiffRow[] {
+  const numbered = numberDiffLines(lines);
+  const hasChange = lines.some((line) => line.op !== 'eq');
+  if (!hasChange) {
+    return numbered.map((line) => ({ kind: 'line', ...line }));
+  }
+
+  const keep = markKeptLines(lines, Math.max(0, contextLines));
+
+  const rows: DiffRow[] = [];
+  let hiddenCount = 0;
+  for (let i = 0; i < numbered.length; i++) {
+    if (keep[i]) {
+      if (hiddenCount > 0) {
+        rows.push({ kind: 'gap', hiddenCount });
+        hiddenCount = 0;
+      }
+      rows.push({ kind: 'line', ...numbered[i] });
+    } else {
+      hiddenCount++;
+    }
+  }
+  if (hiddenCount > 0) rows.push({ kind: 'gap', hiddenCount });
+  return rows;
+}
+
+interface NumberedDiffLine extends DiffLineInput {
+  oldLineNumber: number | null;
+  newLineNumber: number | null;
+}
+
+function numberDiffLines(lines: readonly DiffLineInput[]): NumberedDiffLine[] {
+  let oldLine = 0;
+  let newLine = 0;
+  return lines.map((line) => {
+    // eq は両方、del は変更前のみ、add は変更後のみ行番号を進める
+    const oldLineNumber = line.op === 'add' ? null : ++oldLine;
+    const newLineNumber = line.op === 'del' ? null : ++newLine;
+    return { op: line.op, text: line.text, oldLineNumber, newLineNumber };
+  });
+}
+
+function markKeptLines(
+  lines: readonly DiffLineInput[],
+  contextLines: number,
+): boolean[] {
+  const keep = lines.map(() => false);
+  lines.forEach((line, index) => {
+    if (line.op === 'eq') return;
+    const from = Math.max(0, index - contextLines);
+    const to = Math.min(lines.length - 1, index + contextLines);
+    for (let i = from; i <= to; i++) keep[i] = true;
+  });
+  return keep;
+}
+
+/**
+ * 行差分に含まれる追加行 / 削除行の数を数える
+ */
+export function countDiffLineOps(lines: readonly DiffLineInput[]): {
+  added: number;
+  removed: number;
+} {
+  let added = 0;
+  let removed = 0;
+  for (const line of lines) {
+    if (line.op === 'add') added++;
+    else if (line.op === 'del') removed++;
+  }
+  return { added, removed };
+}
+
+/** 同じ日付でまとめたグループ */
+export interface DateGroup<T> {
+  /** ローカルタイムゾーンでの `YYYY-MM-DD` */
+  key: string;
+  items: T[];
+}
+
+/**
+ * 並び順を保ったまま、連続する同じ日付の要素をグループ化する。
+ *
+ * コミット履歴は新しい順で返るため、連続グループ化で日付見出しが作れる。
+ * 並べ替えは行わない（入力順を尊重する）。
+ */
+export function groupByDay<T>(
+  items: readonly T[],
+  getDate: (item: T) => Date,
+): DateGroup<T>[] {
+  const groups: DateGroup<T>[] = [];
+  for (const item of items) {
+    const key = toLocalDateKey(getDate(item));
+    const last = groups[groups.length - 1];
+    if (last && last.key === key) {
+      last.items.push(item);
+    } else {
+      groups.push({ key, items: [item] });
+    }
+  }
+  return groups;
+}
+
+/**
+ * Date をローカルタイムゾーンの `YYYY-MM-DD` 文字列にする
+ */
+export function toLocalDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
## 概要

バックエンドの git 型バージョン管理API（コミット / 差分 / 復元 / ノード履歴）をフロントに接続し、UIを追加します。

対応エンドポイント（全9件）:

| operationId | 用途 |
|---|---|
| `createCommit` | 保存（手動コミット） |
| `getCommits` | 履歴タイムライン |
| `getProjectDiff` | 未コミットの作業差分 |
| `getCommit` | コミット詳細 |
| `getCommitDiff` | コミット差分 |
| `getCommitEntry` | 追加/削除エントリの中身 |
| `restoreCommit` | プロジェクト全体の復元 |
| `getNodeRevisions` | ノード単位の履歴 |
| `restoreNode` | ノード本文の復元 |

## 追加した画面

1. **履歴タイムライン** — プロジェクトエディタの「変更履歴」タブ。日付ごとにグルーピングし、`commit_type` をバッジで色分け（保存 / 自動保存 / バックアップ / 復元）。件数は「追加 2件・変更 1件」のようにエントリ件数として表示（文字数・行数ではないことが伝わる文言）。
2. **差分ビュー** — 履歴を選ぶと右側（狭い画面では下）に表示。`field_changes` は before/after 並記、`text_diffs` は行番号付きの行差分。
3. **保存ボタン** — タイムライン上部のメッセージ入力＋保存。1〜500文字を入力時に検証。
4. **復元** — プロジェクト全体（破壊的・確認ダイアログ必須）とノード単位（本文のみ）の2種。
5. **ノード単位の履歴** — 執筆 / プロット / キャラクター / メモ 各エディタの「履歴」タブ。

## 仕様上の注意点への対応

- **`added` / `removed` は `field_changes` / `text_diffs` が空** → その旨を表示し、「中身を表示」ボタンで初めて `getCommitEntry` を叩く（不要なリクエストを出さない）。
- **差分はサーバー計算済み** → 差分ライブラリは追加していません。行番号付与と「変更のないN行を省略」の折りたたみだけをフロントで行います。
- **`has_more` は存在しない** → `next_cursor === null` を終端として扱います。`limit` は 1〜100 にクランプ。
- **409 は正常系** → `createCommit` / `restoreCommit` は例外を投げず結果型（`CreateCommitResult` / `RestoreCommitResult`）を返します。保存ボタンは無効化せず、「変更はありません」「既にこの状態です」を穏当な通知として表示します。
- **復元は破壊的** → 必ず確認ダイアログを経由。`backup_commit_id` は「元に戻す」ボタンとしてバナーに出します（`null` のときは出しません）。
- **`restoreNode` は本文のみ** → 確認ダイアログとトーストで「名前・置き場所・並び順は変わらない」ことを明記。フォルダノードでは履歴タブ自体を出しません（400 を踏まない）。
- **`edit_policy` はバージョン管理外** → 復元ダイアログに「AIの編集保護設定は維持される」旨を記載。
- **自動コミット** → 画面フォーカス時に再取得される SWR 既定動作に任せ、明示的な再取得ボタンも用意。**カウントダウン等のUIは作っていません**（タイマーはインメモリで消えるため）。

## 実装上の判断

### 409 を例外ではなく結果型にした理由

アプリは `@tsumugi/adapter` をビルド時に `@tsumugi/adapter-api` へ差し替えます（`apps/desktop/vite.config.ts`）。エラークラスを使うと `instanceof` がバンドル境界を越えられず判定が壊れるため、判別可能な結果型にしました。呼び出し側で分岐漏れも防げます。

### 生成クライアントの必須パラメータ問題

`@tsumugi-chan/client@1.3.1` は `limit` / `cursor` / `base_commit_id` を**必須の `string`** として型付けしており、省略すると `RequiredError` で HTTP リクエスト前に落ちます。一方で空文字を渡すと `?cursor=` が送られてしまいます。

そこで **省略を空文字で表現し、`Configuration` の `pre` ミドルウェアで空クエリを落とす**方式にしました。`stripEmptyQueryParams` は純関数としてテスト済みで、さらに `client.spec.ts` で `fetch` をスタブして**実際に組み立てられるURL**を検証しています。

> 生成クライアント側で該当パラメータが optional になれば、このミドルウェアは削除できます。

## 変更ファイル

- `packages/adapter/core` — `version-types.ts` を新設（`types.ts` が500行ルールを大きく超えないよう分離）、`VersionAdapter` を追加
- `packages/adapter/api` — `adapters/version.ts`、`internal/helpers/{version,query,response-error,node}.ts`
- `packages/ui` — `features/version-history/`（`CommitTimeline` / `CommitDiffView` / `NodeRevisionPanel`）、`lib/version-history-utils.ts`
- `apps/desktop` — `hooks/versions.ts`、`_components/version-history/`、各エディタラッパーにタブ追加

`toNode` を `internal/helpers/node.ts` に切り出して `node` / `version` 両アダプターで共有しています。

## テスト

新規 65 テスト（`@tsumugi/adapter-api` 6 suites / `@tsumugi/ui` 2 suites）。

- `internal/helpers/version.spec.ts` — 生成クライアントの `*FromJSON` を通した変換（`added`/`removed` の空配列、作業差分の `commit_id === null`、`next_cursor` の終端など）
- `internal/helpers/query.spec.ts` — 空クエリ除去と `limit` のクランプ
- `internal/helpers/response-error.spec.ts` — 404 / 409 の判定が `FetchError` / `RequiredError` を誤検出しないこと
- `client.spec.ts` — ミドルウェア込みで実際のリクエストURLを検証
- `version-history-utils.spec.ts` — メッセージ検証、件数整形、行番号付与と折りたたみ、日付グループ化

Storybook: `CommitTimeline` / `CommitDiffView` / `NodeRevisionPanel` に Default / Empty / Interactive（＋ Loading / NoChangesNotice / AfterRestore）を追加。

`turbo run test` / `turbo run tsc` / `turbo run lint` はローカルで全て通っています（lint の 6 warnings は既存ファイルのもの）。

## Test plan

- [ ] CI（test / tsc / lint / build）
- [ ] 実機: 保存 → 履歴に `manual` コミットが増える
- [ ] 実機: 変更なしで保存 → 「変更はありません」が穏当に出る（エラーダイアログにならない・ボタンが無効化されない）
- [ ] 実機: `modified` の差分で before/after と行差分が正しく出る
- [ ] 実機: `added` / `removed` で「中身を表示」を押すと `getCommitEntry` の内容が出る
- [ ] 実機: プロジェクト復元 → 確認ダイアログ → サイドバー/エディタが復元後の状態に更新される
- [ ] 実機: 復元後の「元に戻す」でバックアップコミットに戻れる
- [ ] 実機: 同じ状態へ再復元 → 「既にこの状態です」
- [ ] 実機: ノード履歴から本文復元 → 本文のみ戻り、名前・並び順が変わらない
- [ ] 実機: コミットが 50 件を超えるプロジェクトで「さらに読み込む」が終端まで動く
- [ ] 実機: 10分放置 → `auto` コミットが増え、再取得ボタン/フォーカスで反映される

## 今後の検討事項（このPRでは対応せず）

- トースト基盤がリポジトリに無いため、通知はパネル内のバナーで表現しています。トースト導入時に移行すると自然です。
- 保存ボタンは履歴タブ内にあります。サイドバーヘッダ等に常時表示する導線は別途検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
