### PR TITLE
feat: 自律エージェント Run のUIを追加

### DIFF
--- a/apps/desktop/app/constants/ai-runs.ts
+++ b/apps/desktop/app/constants/ai-runs.ts
@@ -1,0 +1,34 @@
+/**
+ * 自律Run の入力値の制約と既定値。
+ * バックエンド（CreateAIRunRequest）のバリデーションと一致させること。
+ */
+
+/** ゴールの最大文字数 */
+export const AI_RUN_GOAL_MAX_LENGTH = 4000;
+
+/** Run 全体の step 総上限 */
+export const AI_RUN_MAX_STEPS = {
+  min: 1,
+  max: 200,
+  /** 未指定時にバックエンドが使う既定値 */
+  default: 60,
+} as const;
+
+/**
+ * トークン予算。
+ * **出力だけでなく入力を含む合計**であることに注意（毎バッチでコンテキスト全文を再送する）。
+ */
+export const AI_RUN_MAX_TOTAL_TOKENS = {
+  min: 1000,
+  max: 5_000_000,
+  /** 未指定時にバックエンドが使う既定値 */
+  default: 2_000_000,
+} as const;
+
+/**
+ * 実行中の Run の状態をポーリングする間隔（ミリ秒）。
+ *
+ * 進捗（step / トークンの累積）は AIRun から読む必要があるが、バッチ境界を知らせる
+ * チャンク（`start`）が Run では流れないため、実行中はポーリングで追う。
+ */
+export const AI_RUN_POLL_INTERVAL_MS = 3000;

--- a/apps/desktop/app/constants/ai-runs.ts
+++ b/apps/desktop/app/constants/ai-runs.ts
@@ -1,7 +1,23 @@
+import type { AiModelOption } from '@tsumugi/ui';
+
 /**
  * 自律Run の入力値の制約と既定値。
  * バックエンド（CreateAIRunRequest）のバリデーションと一致させること。
  */
+
+/**
+ * 自律Run で選択できるモデル一覧。
+ *
+ * 対話チャットの `AI_MODELS` とは意図的に分けている。`CreateAIRunRequest.model` の
+ * enum に無い値を送ると adapter が黙って落としてバックエンド既定になるため、
+ * チャット側にモデルが追加されたときに Run が勝手に既定へ降格しないようにする。
+ */
+export const AI_RUN_MODELS: AiModelOption[] = [
+  { value: 'gpt-5.4', label: 'GPT-5.4' },
+  { value: 'gpt-5.2', label: 'GPT-5.2' },
+  { value: 'gpt-4o-mini', label: 'GPT-4o mini' },
+  { value: 'claude-3-5-haiku-latest', label: 'Claude 3.5 Haiku' },
+];
 
 /** ゴールの最大文字数 */
 export const AI_RUN_GOAL_MAX_LENGTH = 4000;

--- a/apps/desktop/app/hooks/ai-runs.ts
+++ b/apps/desktop/app/hooks/ai-runs.ts
@@ -1,0 +1,131 @@
+import { useCallback } from 'react';
+import useSWR, { type SWRConfiguration } from 'swr';
+import useSWRMutation from 'swr/mutation';
+import type {
+  AIMessage,
+  AIRun,
+  AIRunStreamChunk,
+  CreateAIRunData,
+  CreateAIRunResult,
+} from '@tsumugi/adapter';
+import { useAdapter } from '~/hooks/useAdapter';
+
+export interface AIRunsKey {
+  type: 'aiRuns';
+  projectId: string;
+}
+
+export interface AIRunKey {
+  type: 'aiRun';
+  runId: string;
+}
+
+/** 自律Run 一覧の SWR キー（グローバル mutate 用） */
+export function toAIRunsKey(projectId: string): AIRunsKey {
+  return { type: 'aiRuns', projectId };
+}
+
+/** 自律Run 詳細の SWR キー（グローバル mutate 用） */
+export function toAIRunKey(runId: string): AIRunKey {
+  return { type: 'aiRun', runId };
+}
+
+/**
+ * プロジェクトの自律Run 一覧を取得する（新しい順）
+ * @param projectId - プロジェクトID
+ * @param config
+ */
+export function useAIRuns(
+  projectId: string,
+  config?: SWRConfiguration<AIRun[], Error>,
+) {
+  const adapter = useAdapter();
+  return useSWR<AIRun[], Error, AIRunsKey>(
+    toAIRunsKey(projectId),
+    ({ projectId }) => adapter.runs.list(projectId),
+    config,
+  );
+}
+
+/**
+ * 自律Run の状態を取得する。
+ *
+ * 進捗（`stepCount` / `totalTokens` の累積）はここから読む。実行中はバッチ境界を
+ * 知らせるチャンクが流れないため、呼び出し側が `refreshInterval` でポーリングする。
+ * @param runId - Run ID
+ * @param config
+ */
+export function useAIRun(
+  runId: string,
+  config?: SWRConfiguration<AIRun, Error>,
+) {
+  const adapter = useAdapter();
+  return useSWR<AIRun, Error, AIRunKey>(
+    toAIRunKey(runId),
+    ({ runId }) => adapter.runs.get(runId),
+    config,
+  );
+}
+
+/**
+ * 自律Run を作成して起動する。
+ *
+ * 進行中の Run が既にある場合（409）は throw せず `{ status: 'conflict' }` を返す。
+ * 呼び出し側で `status` を分岐して進行中 Run への導線を出すこと。
+ * @param projectId - プロジェクトID
+ * @revalidates useAIRuns - 自律Run 一覧を再フェッチする
+ */
+export function useCreateAIRun(projectId: string) {
+  const adapter = useAdapter();
+  return useSWRMutation<CreateAIRunResult, Error, AIRunsKey, CreateAIRunData>(
+    toAIRunsKey(projectId),
+    ({ projectId }, { arg }) => adapter.runs.create(projectId, arg),
+  );
+}
+
+/**
+ * 自律Run を停止する（冪等）。
+ *
+ * 停止は現在のバッチ終了後に確定するため、**戻り値の `status` はまだ `running` の
+ * ことがある。** そのため戻り値をキャッシュへ書かず（`populateCache` を使わない）、
+ * 再フェッチした実際のサーバー状態を表示する。
+ * @param runId - Run ID
+ * @revalidates useAIRun - Run の状態を再フェッチする
+ */
+export function useStopAIRun(runId: string) {
+  const adapter = useAdapter();
+  return useSWRMutation<AIRun, Error, AIRunKey, undefined>(
+    toAIRunKey(runId),
+    ({ runId }) => adapter.runs.stop(runId),
+  );
+}
+
+/**
+ * Run の transcript を取得するコールバックを返す。
+ *
+ * SSE は過去チャンクをリプレイしないため、バッチ境界や再接続のたびにこれで
+ * 取り直して表示内容を置き換える。
+ * @param runId - Run ID
+ */
+export function useFetchAIRunMessages(runId: string) {
+  const adapter = useAdapter();
+  return useCallback(
+    (): Promise<AIMessage[]> => adapter.runs.getMessages(runId),
+    [adapter, runId],
+  );
+}
+
+/**
+ * 自律Run の購読ストリームを開くコールバックを返す。
+ *
+ * 返るストリームは切断時の再接続まで面倒をみるため、呼び出し側は届いたチャンクを
+ * 反映するだけでよい（`transcript` チャンクではメッセージ状態を置き換える）。
+ * @param runId - Run ID
+ */
+export function useSubscribeAIRun(runId: string) {
+  const adapter = useAdapter();
+  return useCallback(
+    (): ReadableStream<AIRunStreamChunk> => adapter.runs.subscribe(runId),
+    [adapter, runId],
+  );
+}

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/workspace-ai-panel.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/workspace-ai-panel.tsx
@@ -10,6 +10,7 @@ import {
   type AiMode,
   type Conversation,
 } from '@tsumugi/ui';
+import { WorkspaceRunPanel } from './workspace-run-panel';
 import { ContextPreviewWrapper } from './context-preview-wrapper';
 import { AIUsageWrapper } from './ai-usage-wrapper';
 import { AIMemoryWrapper } from './ai-memory-wrapper';
@@ -434,6 +435,7 @@ export function WorkspaceAiPanel({
       <Tabs defaultValue="chat" className="flex min-h-0 flex-1 flex-col">
         <TabsList className="mx-3 mt-2 self-start">
           <TabsTrigger value="chat">チャット</TabsTrigger>
+          <TabsTrigger value="run">自律実行</TabsTrigger>
           <TabsTrigger value="context">コンテキスト</TabsTrigger>
           <TabsTrigger value="usage">使用量</TabsTrigger>
           <TabsTrigger value="memory">メモリ</TabsTrigger>
@@ -488,6 +490,9 @@ export function WorkspaceAiPanel({
               }
             />
           )}
+        </TabsContent>
+        <TabsContent value="run" className="flex min-h-0 flex-1 flex-col">
+          <WorkspaceRunPanel projectId={projectId} />
         </TabsContent>
         <TabsContent value="context" className="min-h-0 flex-1">
           <ContextPreviewWrapper projectId={projectId} mode={aiMode} />

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/workspace-run-panel.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/workspace-run-panel.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AiRunPanel,
+  type AiRunStartInput,
+  type AiRunStartError,
+} from '@tsumugi/ui';
+import type { CreateAIRunData } from '@tsumugi/adapter';
+import {
+  useAIRun,
+  useAIRuns,
+  useCreateAIRun,
+  useStopAIRun,
+} from '~/hooks/ai-runs';
+import { AI_MODELS } from '~/constants/ai-models';
+import {
+  AI_RUN_GOAL_MAX_LENGTH,
+  AI_RUN_MAX_STEPS,
+  AI_RUN_MAX_TOTAL_TOKENS,
+  AI_RUN_POLL_INTERVAL_MS,
+} from '~/constants/ai-runs';
+import { useAIRunStream } from '../_hooks/useAIRunStream';
+import {
+  buildRunTranscript,
+  isActiveRun,
+  toAiRunDetail,
+  toAiRunSummaries,
+} from '../_utils/ai-run-utils';
+
+interface WorkspaceRunPanelProps {
+  projectId: string;
+}
+
+/**
+ * 自律エージェント Run パネル（データ取得 + ストリーム購読）。
+ *
+ * runId が確定してから RunContent をマウントする。
+ */
+export function WorkspaceRunPanel({ projectId }: WorkspaceRunPanelProps) {
+  const { data: runs } = useAIRuns(projectId);
+  const { trigger: triggerCreate, isMutating: isStarting } =
+    useCreateAIRun(projectId);
+
+  const [selectedRunId, setSelectedRunId] = useState<string | undefined>();
+  const [startError, setStartError] = useState<AiRunStartError | null>(null);
+
+  // 進行中の Run があれば初回だけ自動で開く（別タブ・再読み込み後でも進捗に復帰できる）。
+  // 「新しい実行」で意図的にフォームへ戻した場合に引き戻さないよう、初回限定にする。
+  const didAutoSelectRef = useRef(false);
+  useEffect(() => {
+    if (didAutoSelectRef.current || !runs) return;
+    didAutoSelectRef.current = true;
+    const active = runs.find(isActiveRun);
+    if (active) setSelectedRunId(active.id);
+  }, [runs]);
+
+  const handleStartRun = useCallback(
+    async (input: AiRunStartInput) => {
+      // 二重送信抑止（UI 側の disabled と合わせた二重の防御）
+      if (isStarting) return;
+      setStartError(null);
+
+      const data: CreateAIRunData = {
+        goal: input.goal,
+        ...(input.model ? { model: input.model } : {}),
+        maxSteps: input.maxSteps,
+        maxTotalTokens: input.maxTotalTokens,
+      };
+
+      try {
+        const result = await triggerCreate(data);
+        if (!result) return;
+        // 1プロジェクトにつき同時に走れる Run は1本だけ。
+        // 409 は結果の型で返るので、進行中 Run への導線を出す。
+        if (result.status === 'conflict') {
+          setStartError({
+            message: result.message,
+            ...(result.runningRun
+              ? { runningRunId: result.runningRun.id }
+              : {}),
+          });
+          return;
+        }
+        setSelectedRunId(result.run.id);
+      } catch (e) {
+        setStartError({
+          message: `自律実行の開始に失敗しました: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        });
+      }
+    },
+    [isStarting, triggerCreate],
+  );
+
+  const handleSelectRun = useCallback((runId: string) => {
+    setStartError(null);
+    setSelectedRunId(runId);
+  }, []);
+
+  const handleNewRun = useCallback(() => {
+    setStartError(null);
+    setSelectedRunId(undefined);
+  }, []);
+
+  const runSummaries = useMemo(() => toAiRunSummaries(runs), [runs]);
+
+  if (!selectedRunId) {
+    return (
+      <AiRunPanel
+        run={null}
+        runs={runSummaries}
+        models={AI_MODELS}
+        isStarting={isStarting}
+        startError={startError}
+        onStartRun={handleStartRun}
+        onSelectRun={handleSelectRun}
+        goalMaxLength={AI_RUN_GOAL_MAX_LENGTH}
+        maxStepsRange={AI_RUN_MAX_STEPS}
+        maxTotalTokensRange={AI_RUN_MAX_TOTAL_TOKENS}
+      />
+    );
+  }
+
+  return (
+    <RunContent
+      key={selectedRunId}
+      projectId={projectId}
+      runId={selectedRunId}
+      runSummaries={runSummaries}
+      onSelectRun={handleSelectRun}
+      onNewRun={handleNewRun}
+    />
+  );
+}
+
+interface RunContentProps {
+  projectId: string;
+  runId: string;
+  runSummaries: ReturnType<typeof toAiRunSummaries>;
+  onSelectRun: (runId: string) => void;
+  onNewRun: () => void;
+}
+
+/**
+ * runId 確定後の表示。Run の状態を購読しつつ、進捗はポーリングで追う。
+ */
+function RunContent({
+  projectId,
+  runId,
+  runSummaries,
+  onSelectRun,
+  onNewRun,
+}: RunContentProps) {
+  const { messages, streamingContent, plan, isReconnecting, transientError } =
+    useAIRunStream(projectId, runId);
+
+  // step / トークンの累積は AIRun から読む。バッチ境界を知らせるチャンクが
+  // 流れないため、実行中はポーリングで追う。
+  const { data: run, isLoading: isLoadingRun } = useAIRun(runId, {
+    refreshInterval: (latest) =>
+      isActiveRun(latest) ? AI_RUN_POLL_INTERVAL_MS : 0,
+  });
+
+  const { trigger: triggerStop } = useStopAIRun(runId);
+  const [stopRequested, setStopRequested] = useState(false);
+
+  const handleStopRun = useCallback(() => {
+    // stopAIRun は冪等。ただしレスポンスの status はまだ running のことがあるため、
+    // 「停止済み」の判定には使わず、実際に非アクティブになるまで要求中として扱う。
+    setStopRequested(true);
+    void triggerStop().catch((e) => {
+      console.error('[ai-run] Failed to stop the run:', e);
+      setStopRequested(false);
+    });
+  }, [triggerStop]);
+
+  const isActive = isActiveRun(run);
+  useEffect(() => {
+    // run-status(stopped) やポーリングで停止が確定したら要求中表示を解除する
+    if (!isActive) setStopRequested(false);
+  }, [isActive]);
+
+  const transcript = useMemo(() => buildRunTranscript(messages), [messages]);
+  const detail = useMemo(
+    () => (run ? toAiRunDetail(run, plan) : null),
+    [run, plan],
+  );
+
+  return (
+    <AiRunPanel
+      run={detail}
+      isLoadingRun={isLoadingRun}
+      messages={transcript}
+      streamingContent={streamingContent}
+      runs={runSummaries}
+      models={AI_MODELS}
+      isStopping={stopRequested}
+      isReconnecting={isReconnecting}
+      transientError={transientError}
+      onSelectRun={onSelectRun}
+      onNewRun={onNewRun}
+      onStopRun={handleStopRun}
+      goalMaxLength={AI_RUN_GOAL_MAX_LENGTH}
+      maxStepsRange={AI_RUN_MAX_STEPS}
+      maxTotalTokensRange={AI_RUN_MAX_TOTAL_TOKENS}
+    />
+  );
+}

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/workspace-run-panel.tsx
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_components/workspace-run-panel.tsx
@@ -11,9 +11,9 @@ import {
   useCreateAIRun,
   useStopAIRun,
 } from '~/hooks/ai-runs';
-import { AI_MODELS } from '~/constants/ai-models';
 import {
   AI_RUN_GOAL_MAX_LENGTH,
+  AI_RUN_MODELS,
   AI_RUN_MAX_STEPS,
   AI_RUN_MAX_TOTAL_TOKENS,
   AI_RUN_POLL_INTERVAL_MS,
@@ -42,6 +42,8 @@ export function WorkspaceRunPanel({ projectId }: WorkspaceRunPanelProps) {
 
   const [selectedRunId, setSelectedRunId] = useState<string | undefined>();
   const [startError, setStartError] = useState<AiRunStartError | null>(null);
+  // 打ち切られた Run の続きを実行しやすくするため、直前のゴールを引き継ぐ
+  const [prefillGoal, setPrefillGoal] = useState<string | undefined>();
 
   // 進行中の Run があれば初回だけ自動で開く（別タブ・再読み込み後でも進捗に復帰できる）。
   // 「新しい実行」で意図的にフォームへ戻した場合に引き戻さないよう、初回限定にする。
@@ -97,8 +99,9 @@ export function WorkspaceRunPanel({ projectId }: WorkspaceRunPanelProps) {
     setSelectedRunId(runId);
   }, []);
 
-  const handleNewRun = useCallback(() => {
+  const handleNewRun = useCallback((goal?: string) => {
     setStartError(null);
+    setPrefillGoal(goal);
     setSelectedRunId(undefined);
   }, []);
 
@@ -109,9 +112,10 @@ export function WorkspaceRunPanel({ projectId }: WorkspaceRunPanelProps) {
       <AiRunPanel
         run={null}
         runs={runSummaries}
-        models={AI_MODELS}
+        models={AI_RUN_MODELS}
         isStarting={isStarting}
         startError={startError}
+        initialGoal={prefillGoal}
         onStartRun={handleStartRun}
         onSelectRun={handleSelectRun}
         goalMaxLength={AI_RUN_GOAL_MAX_LENGTH}
@@ -138,7 +142,7 @@ interface RunContentProps {
   runId: string;
   runSummaries: ReturnType<typeof toAiRunSummaries>;
   onSelectRun: (runId: string) => void;
-  onNewRun: () => void;
+  onNewRun: (prefillGoal?: string) => void;
 }
 
 /**
@@ -151,15 +155,32 @@ function RunContent({
   onSelectRun,
   onNewRun,
 }: RunContentProps) {
-  const { messages, streamingContent, plan, isReconnecting, transientError } =
-    useAIRunStream(projectId, runId);
+  const {
+    messages,
+    streamingContent,
+    plan,
+    isReconnecting,
+    transientError,
+    fatalError,
+    retry,
+  } = useAIRunStream(projectId, runId);
 
   // step / トークンの累積は AIRun から読む。バッチ境界を知らせるチャンクが
   // 流れないため、実行中はポーリングで追う。
-  const { data: run, isLoading: isLoadingRun } = useAIRun(runId, {
+  const {
+    data: run,
+    isLoading: isLoadingRun,
+    error: runError,
+    mutate: mutateRun,
+  } = useAIRun(runId, {
     refreshInterval: (latest) =>
       isActiveRun(latest) ? AI_RUN_POLL_INTERVAL_MS : 0,
   });
+
+  const handleRetryConnection = useCallback(() => {
+    void mutateRun();
+    retry();
+  }, [mutateRun, retry]);
 
   const { trigger: triggerStop } = useStopAIRun(runId);
   const [stopRequested, setStopRequested] = useState(false);
@@ -193,10 +214,15 @@ function RunContent({
       messages={transcript}
       streamingContent={streamingContent}
       runs={runSummaries}
-      models={AI_MODELS}
+      models={AI_RUN_MODELS}
       isStopping={stopRequested}
       isReconnecting={isReconnecting}
       transientError={transientError}
+      fatalError={fatalError}
+      onRetryConnection={handleRetryConnection}
+      loadError={
+        runError ? `実行を読み込めませんでした: ${runError.message}` : null
+      }
       onSelectRun={onSelectRun}
       onNewRun={onNewRun}
       onStopRun={handleStopRun}

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_hooks/useAIRunStream.ts
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_hooks/useAIRunStream.ts
@@ -24,15 +24,28 @@ export interface AIRunStreamState {
    * 「失敗した」ではなく「リトライしている」として見せる。
    */
   transientError: string | null;
+  /**
+   * 購読を打ち切ったときのエラー。
+   * こちらは復旧しないので、明示的に再接続をユーザーに促す。
+   */
+  fatalError: string | null;
+  /** 打ち切り後に購読をやり直す */
+  retry: () => void;
 }
 
-const INITIAL_STATE: AIRunStreamState = {
+type AIRunStreamData = Omit<AIRunStreamState, 'retry'>;
+
+const INITIAL_STATE: AIRunStreamData = {
   messages: [],
   streamingContent: null,
   plan: null,
   isReconnecting: false,
   transientError: null,
+  fatalError: null,
 };
+
+/** ツリーを持つコンテンツ種別（contentType 不明時の一括再取得用） */
+const CONTENT_TYPES = ['plot', 'character', 'memo', 'writing'] as const;
 
 /**
  * 自律Run のストリームを購読して表示状態に反映する。
@@ -51,7 +64,10 @@ export function useAIRunStream(
   const subscribe = useSubscribeAIRun(runId ?? '');
   const fetchMessages = useFetchAIRunMessages(runId ?? '');
 
-  const [state, setState] = useState<AIRunStreamState>(INITIAL_STATE);
+  const [state, setState] = useState<AIRunStreamData>(INITIAL_STATE);
+  // 打ち切り後の再購読トリガー（値が変わると購読 effect が張り直される）
+  const [retryToken, setRetryToken] = useState(0);
+  const retry = useCallback(() => setRetryToken((token) => token + 1), []);
 
   /**
    * 自律Run が作ったノードは canon_status: 'draft' で即座に保存済み。
@@ -59,7 +75,14 @@ export function useAIRunStream(
    */
   const revalidateContent = useCallback(
     (contentType: EditorTabType | undefined, targetId: string | undefined) => {
-      if (!contentType) return;
+      if (!contentType) {
+        // contentType は任意項目。分からなくてもノードは既に保存済みなので、
+        // 取りこぼすくらいなら全ツリーを引き直す。
+        for (const type of CONTENT_TYPES) {
+          void globalMutate(toContentTreeKey(type, projectId));
+        }
+        return;
+      }
       if (contentType === 'project') {
         void globalMutate({ type: 'project', id: projectId });
         return;
@@ -83,12 +106,25 @@ export function useAIRunStream(
     let cancelled = false;
     const reader = subscribe().getReader();
 
-    /** transcript を取り直して、畳み込み済みのストリーミングテキストを捨てる */
-    const resyncTranscript = async () => {
+    /**
+     * transcript を取り直す。
+     *
+     * ストリーミング中のテキストは「取り直した transcript に含まれている」ときだけ
+     * 捨てる。`usage` が発言の保存より先に届くことがあり、無条件に捨てると
+     * 目の前で流れていた文章が一瞬消える。
+     */
+    const resyncTranscript = async (force = false) => {
       try {
         const messages = await fetchMessages();
         if (cancelled) return;
-        setState((prev) => ({ ...prev, messages, streamingContent: null }));
+        setState((prev) => ({
+          ...prev,
+          messages,
+          streamingContent:
+            force || messages.length > prev.messages.length
+              ? null
+              : prev.streamingContent,
+        }));
       } catch (e) {
         console.error('[ai-run] Failed to resync the transcript:', e);
       }
@@ -97,7 +133,13 @@ export function useAIRunStream(
     const pump = async () => {
       while (!cancelled) {
         const { done, value } = await reader.read();
-        if (done || cancelled) break;
+        if (done || cancelled) {
+          // ストリームが閉じたら再接続待ちの表示を残さない
+          if (!cancelled) {
+            setState((prev) => ({ ...prev, isReconnecting: false }));
+          }
+          break;
+        }
 
         switch (value.type) {
           // 購読開始時・再接続時のスナップショット。追記ではなく置き換える
@@ -135,7 +177,7 @@ export function useAIRunStream(
             void globalMutate(toAIRunsKey(projectId));
             if (value.finishReason != null) {
               // 終端。最終メッセージを取り込む
-              await resyncTranscript();
+              await resyncTranscript(true);
             }
             break;
 
@@ -151,16 +193,29 @@ export function useAIRunStream(
             );
             break;
 
-          // error は終端ではない（最大2回リトライされる）
+          // error は終端ではない（同じバッチが最大2回リトライされる）。
+          // リトライされたバッチのテキストが継ぎ足されて二重に見えるのを防ぐため、
+          // 未確定のストリーミングテキストは破棄する。
           case 'error':
             setState((prev) => ({
               ...prev,
+              streamingContent: null,
               transientError: value.error ?? '不明なエラー',
             }));
             break;
 
           case 'reconnecting':
             setState((prev) => ({ ...prev, isReconnecting: true }));
+            break;
+
+          // クライアント側で購読を打ち切った（error とは別物で、復旧しない）
+          case 'disconnected':
+            setState((prev) => ({
+              ...prev,
+              isReconnecting: false,
+              transientError: null,
+              fatalError: value.error ?? 'ストリームが切断されました',
+            }));
             break;
 
           // tool_call / proposal は transcript の順序が正なので、
@@ -188,7 +243,8 @@ export function useAIRunStream(
     fetchMessages,
     globalMutate,
     revalidateContent,
+    retryToken,
   ]);
 
-  return state;
+  return { ...state, retry };
 }

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_hooks/useAIRunStream.ts
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_hooks/useAIRunStream.ts
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useSWRConfig } from 'swr';
+import type { AIMessage, AIRunPlanItem, EditorTabType } from '@tsumugi/adapter';
+import {
+  toAIRunKey,
+  toAIRunsKey,
+  useFetchAIRunMessages,
+  useSubscribeAIRun,
+} from '~/hooks/ai-runs';
+import { toContentItemKey, toContentTreeKey } from '../_utils/ai-panel-utils';
+
+export interface AIRunStreamState {
+  /** transcript（購読・バッチ境界ごとに取り直した結果で置き換わる） */
+  messages: AIMessage[];
+  /** 未確定のアシスタント発言。バッチ境界で transcript に畳み込まれる */
+  streamingContent: string | null;
+  /** ストリームから受け取った最新の計画（未受信なら null） */
+  plan: AIRunPlanItem[] | null;
+  /** 切断からの再接続待機中 */
+  isReconnecting: boolean;
+  /**
+   * リトライ中のエラー。
+   * `error` チャンクは終端ではなくバックエンドが最大2回リトライするため、
+   * 「失敗した」ではなく「リトライしている」として見せる。
+   */
+  transientError: string | null;
+}
+
+const INITIAL_STATE: AIRunStreamState = {
+  messages: [],
+  streamingContent: null,
+  plan: null,
+  isReconnecting: false,
+  transientError: null,
+};
+
+/**
+ * 自律Run のストリームを購読して表示状態に反映する。
+ *
+ * 再接続はアダプター（`adapter.runs.subscribe`）が面倒をみるため、ここでは
+ * 届いたチャンクを状態へ反映するだけ。
+ *
+ * @param projectId - プロジェクトID（ツリー再取得に使う）
+ * @param runId - 購読する Run ID。undefined の間は購読しない
+ */
+export function useAIRunStream(
+  projectId: string,
+  runId: string | undefined,
+): AIRunStreamState {
+  const { mutate: globalMutate } = useSWRConfig();
+  const subscribe = useSubscribeAIRun(runId ?? '');
+  const fetchMessages = useFetchAIRunMessages(runId ?? '');
+
+  const [state, setState] = useState<AIRunStreamState>(INITIAL_STATE);
+
+  /**
+   * 自律Run が作ったノードは canon_status: 'draft' で即座に保存済み。
+   * Run の完了を待たずにツリーへ反映する。
+   */
+  const revalidateContent = useCallback(
+    (contentType: EditorTabType | undefined, targetId: string | undefined) => {
+      if (!contentType) return;
+      if (contentType === 'project') {
+        void globalMutate({ type: 'project', id: projectId });
+        return;
+      }
+      if (targetId) {
+        void globalMutate(toContentItemKey(contentType, targetId));
+      }
+      void globalMutate(toContentTreeKey(contentType, projectId));
+    },
+    [globalMutate, projectId],
+  );
+
+  useEffect(() => {
+    if (!runId) {
+      setState(INITIAL_STATE);
+      return;
+    }
+
+    setState(INITIAL_STATE);
+
+    let cancelled = false;
+    const reader = subscribe().getReader();
+
+    /** transcript を取り直して、畳み込み済みのストリーミングテキストを捨てる */
+    const resyncTranscript = async () => {
+      try {
+        const messages = await fetchMessages();
+        if (cancelled) return;
+        setState((prev) => ({ ...prev, messages, streamingContent: null }));
+      } catch (e) {
+        console.error('[ai-run] Failed to resync the transcript:', e);
+      }
+    };
+
+    const pump = async () => {
+      while (!cancelled) {
+        const { done, value } = await reader.read();
+        if (done || cancelled) break;
+
+        switch (value.type) {
+          // 購読開始時・再接続時のスナップショット。追記ではなく置き換える
+          case 'transcript':
+            setState((prev) => ({
+              ...prev,
+              messages: value.messages ?? [],
+              streamingContent: null,
+              isReconnecting: false,
+              transientError: null,
+            }));
+            break;
+
+          case 'text':
+            setState((prev) => ({
+              ...prev,
+              streamingContent:
+                (prev.streamingContent ?? '') + (value.content ?? ''),
+              transientError: null,
+            }));
+            break;
+
+          case 'plan':
+            setState((prev) => ({
+              ...prev,
+              plan: value.plan ?? [],
+              transientError: null,
+            }));
+            break;
+
+          case 'run_status':
+            setState((prev) => ({ ...prev, transientError: null }));
+            // 進捗の累積値と一覧の表示を実際のサーバー状態に合わせる
+            void globalMutate(toAIRunKey(runId));
+            void globalMutate(toAIRunsKey(projectId));
+            if (value.finishReason != null) {
+              // 終端。最終メッセージを取り込む
+              await resyncTranscript();
+            }
+            break;
+
+          // バッチ境界。ここまでの発言はバックエンドに保存済みなので取り直す
+          case 'usage':
+            await resyncTranscript();
+            break;
+
+          case 'proposal_result':
+            revalidateContent(
+              value.proposalFeedback?.contentType,
+              value.proposalFeedback?.targetId,
+            );
+            break;
+
+          // error は終端ではない（最大2回リトライされる）
+          case 'error':
+            setState((prev) => ({
+              ...prev,
+              transientError: value.error ?? '不明なエラー',
+            }));
+            break;
+
+          case 'reconnecting':
+            setState((prev) => ({ ...prev, isReconnecting: true }));
+            break;
+
+          // tool_call / proposal は transcript の順序が正なので、
+          // 到着順に依存した表示はしない
+          default:
+            break;
+        }
+      }
+    };
+
+    pump().catch((e) => {
+      if (!cancelled) console.error('[ai-run] stream pump failed:', e);
+    });
+
+    return () => {
+      cancelled = true;
+      void reader.cancel().catch(() => {
+        // 購読の後片付けなので失敗しても無視する
+      });
+    };
+  }, [
+    runId,
+    projectId,
+    subscribe,
+    fetchMessages,
+    globalMutate,
+    revalidateContent,
+  ]);
+
+  return state;
+}

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_utils/ai-run-utils.ts
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_utils/ai-run-utils.ts
@@ -1,0 +1,92 @@
+import type { AIMessage, AIRun, AIRunPlanItem } from '@tsumugi/adapter';
+import type { AiRunDetail, AiRunMessage, AiRunSummary } from '@tsumugi/ui';
+
+/**
+ * Run の transcript を UI 表示用のメッセージ列に変換する。
+ *
+ * 表示するのは text と proposal だけ。tool_call / tool_result は
+ * LLM ↔ アダプター間の内部メッセージなので出さない。
+ * 自律Run の提案は承認を挟まず適用済みなので、承認ボタンではなく
+ * 「作成/更新しました」の行として表示する。
+ */
+export function buildRunTranscript(
+  messages: AIMessage[] | undefined,
+): AiRunMessage[] {
+  if (!messages) return [];
+
+  const items: AiRunMessage[] = [];
+  for (const message of messages) {
+    if (message.messageType === 'text') {
+      if (!message.content.trim()) continue;
+      if (message.role !== 'user' && message.role !== 'assistant') continue;
+      items.push({
+        id: message.id,
+        kind: 'text',
+        role: message.role,
+        content: message.content,
+      });
+    } else if (message.messageType === 'proposal') {
+      items.push({
+        id: message.id,
+        kind: 'edit',
+        action: message.proposal.action,
+        contentType: message.proposal.contentType,
+        targetName: message.proposal.targetName,
+      });
+    }
+  }
+  return items;
+}
+
+/**
+ * Run（adapter 型）を UI の表示用 Run に変換する。
+ *
+ * 計画はストリームの `plan` チャンクの方が新しいことがあるため、
+ * `livePlan` があればそちらを優先する。
+ */
+export function toAiRunDetail(
+  run: AIRun,
+  livePlan: AIRunPlanItem[] | null,
+): AiRunDetail {
+  return {
+    id: run.id,
+    goal: run.goal,
+    status: run.status,
+    finishReason: run.finishReason,
+    plan: livePlan ?? run.plan,
+    stepCount: run.stepCount,
+    maxSteps: run.maxSteps,
+    // 累積トークンは Run から読む（usage チャンクはバッチ単体の値なので使わない）
+    totalTokens: run.totalTokens,
+    maxTotalTokens: run.maxTotalTokens,
+    createdNodeCount: run.createdNodeCount,
+    subagentCount: run.subagentCount,
+    lastError: run.lastError,
+  };
+}
+
+/**
+ * Run 一覧を UI の表示用サマリに変換する
+ */
+export function toAiRunSummaries(runs: AIRun[] | undefined): AiRunSummary[] {
+  if (!runs) return [];
+  return runs.map((run) => ({
+    id: run.id,
+    goal: run.goal,
+    status: run.status,
+    finishReason: run.finishReason,
+    createdAt: run.createdAt,
+  }));
+}
+
+/**
+ * 進行中（停止操作が意味を持つ）Run かどうか
+ */
+export function isActiveRun(run: AIRun | undefined): boolean {
+  if (!run) return false;
+  return (
+    run.status === 'queued' ||
+    run.status === 'running' ||
+    run.status === 'paused'
+  );
+}

--- a/apps/desktop/app/routes/(private)/workspace/[projectId]/_utils/ai-run-utils.ts
+++ b/apps/desktop/app/routes/(private)/workspace/[projectId]/_utils/ai-run-utils.ts
@@ -32,6 +32,9 @@ export function buildRunTranscript(
         action: message.proposal.action,
         contentType: message.proposal.contentType,
         targetName: message.proposal.targetName,
+        // 編集保護（editPolicy）やコンフリクトで弾かれた提案もあるため、
+        // 状態を渡して「適用しました」と言い切らないようにする
+        status: message.proposal.status,
       });
     }
   }

--- a/packages/adapter/api/src/adapter.ts
+++ b/packages/adapter/api/src/adapter.ts
@@ -9,6 +9,7 @@ import { createMemoAdapter } from '@/adapters/memo';
 import { createWritingAdapter } from '@/adapters/writing';
 import { createSettingsAdapter } from '@/adapters/settings';
 import { createAIAdapter } from '@/adapters/ai';
+import { createAIRunAdapter } from '@/adapters/run';
 import { createConsistencyAdapter } from '@/adapters/consistency';
 import { createGlossaryAdapter } from '@/adapters/glossary';
 import { createInstructionAdapter } from '@/adapters/instruction';
@@ -39,6 +40,7 @@ export function createAdapter(config: AdapterConfig = {}): Adapter {
     memos: createMemoAdapter(clients),
     writings: createWritingAdapter(clients),
     ai: createAIAdapter(clients),
+    runs: createAIRunAdapter(clients),
     consistency: createConsistencyAdapter(clients),
     glossary: createGlossaryAdapter(clients),
     instructions: createInstructionAdapter(clients),

--- a/packages/adapter/api/src/adapters/ai.ts
+++ b/packages/adapter/api/src/adapters/ai.ts
@@ -13,32 +13,27 @@ import {
   AIMemory as AdapterAIMemory,
   AIProjectUsage as AdapterAIProjectUsage,
   AIProposalFeedback,
-  AITextMessage,
-  AIToolCallMessage,
-  AIToolResultMessage,
-  AIProposalMessage,
 } from '@tsumugi/adapter';
 import type { ApiClients } from '@/client';
 import {
   AIModelConfigModelEnum,
   ProposalResultStreamChunkFromJSON,
   type AISession as ClientAISession,
-  type AIMessage as ClientAIMessage,
   type AIMemory as ClientAIMemory,
   type AIModelConfig as ClientAIModelConfig,
   type AIChatContext as ClientAIChatContext,
   type AIProjectUsage as ClientAIProjectUsage,
   type AIContextPack as ClientAIContextPack,
   type ChatRequest as ClientChatRequest,
-  type AIProposalFeedback as ClientAIProposalFeedback,
 } from '@tsumugi-chan/client';
 import {
   fetchSSE,
   hasType,
   parseSSEEvent,
   parseSSEStream,
-  toAIProposal,
+  toProposalFeedback,
 } from '@/internal/helpers/sse';
+import { toMessage } from '@/internal/helpers/message';
 
 // ─── 型変換 ───
 
@@ -63,58 +58,6 @@ function toContextPack(api: ClientAIContextPack): AIContextPack {
     })),
     totalCharCount: api.totalCharCount,
   };
-}
-
-function toMessage(api: ClientAIMessage): AdapterAIMessage {
-  const role = api.role;
-  const messageType = api.messageType;
-  const base = {
-    id: api.id,
-    sessionId: api.sessionId,
-    role,
-  };
-
-  switch (messageType) {
-    case 'text': {
-      const textContent = api.content
-        .filter((c) => c.type === 'text')
-        .map((c) => c.text)
-        .join('');
-      return {
-        ...base,
-        messageType: 'text',
-        content: textContent,
-      } satisfies AITextMessage;
-    }
-    case 'tool_call': {
-      return {
-        ...base,
-        messageType: 'tool_call',
-        content: JSON.stringify(api.content),
-      } satisfies AIToolCallMessage;
-    }
-    // tool_result / feedback は LLM ↔ アダプター間・フロント→AI 間の内部メッセージ。
-    // UI には表示しない（buildDisplayMessages が text / proposal のみ表示）ため
-    // tool_result として畳み込む。
-    case 'tool_result':
-    case 'feedback': {
-      return {
-        ...base,
-        messageType: 'tool_result',
-        content: JSON.stringify(api.content),
-      } satisfies AIToolResultMessage;
-    }
-    case 'proposal': {
-      if (api.proposal) {
-        return {
-          ...base,
-          messageType: 'proposal',
-          proposal: toAIProposal(api.proposal),
-        } satisfies AIProposalMessage;
-      }
-    }
-  }
-  return { ...base, messageType: 'text', content: '' };
 }
 
 function toMemory(api: ClientAIMemory): AdapterAIMemory {
@@ -142,16 +85,6 @@ function toUsage(api: ClientAIProjectUsage): AdapterAIProjectUsage {
       completionTokens: api.total.completionTokens,
       totalTokens: api.total.totalTokens,
     },
-  };
-}
-
-function toFeedback(feedback: ClientAIProposalFeedback): AIProposalFeedback {
-  return {
-    toolCallId: feedback.toolCallId,
-    status: feedback.status,
-    contentType: feedback.contentType,
-    targetId: feedback.targetId,
-    conflictDetails: feedback.conflictDetails,
   };
 }
 
@@ -377,7 +310,7 @@ export async function parseProposalSSEResponse(
       }
       if (hasType(parsed) && parsed.type === 'proposal-result') {
         const result = ProposalResultStreamChunkFromJSON(parsed).result;
-        feedback = toFeedback(result.feedback);
+        feedback = toProposalFeedback(result.feedback);
         hasStream = result.hasStream;
         // proposal-result と同じバッチに含まれる後続フレームは AI 応答へ引き継ぐ
         leftoverFrames = parts.slice(i + 1);

--- a/packages/adapter/api/src/adapters/run.ts
+++ b/packages/adapter/api/src/adapters/run.ts
@@ -140,6 +140,12 @@ export function createAIRunAdapter(clients: ApiClients): AIRunAdapter {
             runningRun: await findActiveRun(projectId),
           };
         }
+        // 409 以外（422 のバリデーションエラー等）も、生成クライアントの
+        // 既定メッセージは "Response returned an error code" で情報がないため、
+        // 本文からメッセージを取り出して投げ直す。
+        if (e instanceof ResponseError) {
+          throw new Error(await readErrorMessage(e.response, e.message));
+        }
         throw e;
       }
     },

--- a/packages/adapter/api/src/adapters/run.ts
+++ b/packages/adapter/api/src/adapters/run.ts
@@ -1,0 +1,182 @@
+import {
+  CreateAIRunRequestModelEnum,
+  ResponseError,
+  type CreateAIRunRequest as ClientCreateAIRunRequest,
+} from '@tsumugi-chan/client';
+import type {
+  AIMessage,
+  AIRun,
+  AIRunAdapter,
+  AIRunStreamChunk,
+  AIRunSubscribeOptions,
+  CreateAIRunData,
+  CreateAIRunResult,
+} from '@tsumugi/adapter';
+import type { ApiClients } from '@/client';
+import { fetchSSE } from '@/internal/helpers/sse';
+import { toMessage } from '@/internal/helpers/message';
+import { createDurableRunStream, toAIRun } from '@/internal/helpers/run';
+
+/**
+ * 409（同時実行違反）時にバックエンドが返すメッセージのフォールバック。
+ * レスポンス本文を読めなかった場合に使う。
+ */
+const CONFLICT_FALLBACK_MESSAGE =
+  'このプロジェクトでは既に自律実行が進行中です。';
+
+/**
+ * 進行中とみなす Run のステータス。
+ * `paused` は現状どこからも遷移しないが、将来の予約として含める。
+ */
+const ACTIVE_RUN_STATUSES: readonly AIRun['status'][] = [
+  'queued',
+  'running',
+  'paused',
+];
+
+/**
+ * モデル名が API の許容モデル（生成 enum）かどうかを判定する型ガード。
+ * core 側は `model?: string` で開いているため、ここで既知モデルに絞り込む。
+ */
+function isCreateRunModelEnum(
+  model: string,
+): model is CreateAIRunRequestModelEnum {
+  return (Object.values(CreateAIRunRequestModelEnum) as string[]).includes(
+    model,
+  );
+}
+
+function toClientCreateRequest(
+  data: CreateAIRunData,
+): ClientCreateAIRunRequest {
+  return {
+    goal: data.goal,
+    model:
+      data.model && isCreateRunModelEnum(data.model) ? data.model : undefined,
+    maxSteps: data.maxSteps,
+    maxTotalTokens: data.maxTotalTokens,
+  };
+}
+
+/**
+ * エラー本文が `{ message: string | string[] }` 形をしているかを判定する型ガード。
+ */
+function hasErrorMessage(
+  value: unknown,
+): value is { message: string | string[] } {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('message' in value)) return false;
+  const message = value.message;
+  return (
+    typeof message === 'string' ||
+    (Array.isArray(message) && message.every((m) => typeof m === 'string'))
+  );
+}
+
+/**
+ * エラーレスポンスの本文からメッセージを取り出す。読めなければ fallback を返す。
+ */
+async function readErrorMessage(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  try {
+    const body: unknown = await response.clone().json();
+    if (hasErrorMessage(body)) {
+      const { message } = body;
+      const text = Array.isArray(message) ? message.join(' / ') : message;
+      if (text.trim()) return text;
+    }
+  } catch {
+    // 本文が JSON でない / すでに読まれている場合は fallback を使う
+  }
+  return fallback;
+}
+
+export function createAIRunAdapter(clients: ApiClients): AIRunAdapter {
+  const fetchMessages = async (runId: string): Promise<AIMessage[]> => {
+    const messages = await clients.runs.getAIRunMessages({ runId });
+    return messages.map(toMessage);
+  };
+
+  /**
+   * 進行中の Run を取得する（409 の導線用）。失敗しても null を返して主目的を邪魔しない。
+   */
+  const findActiveRun = async (projectId: string): Promise<AIRun | null> => {
+    try {
+      const runs = await clients.projects.getAIRuns({ projectId });
+      const active = runs
+        .map(toAIRun)
+        .find((run) => ACTIVE_RUN_STATUSES.includes(run.status));
+      return active ?? null;
+    } catch (e) {
+      console.error('[adapter-api] Failed to look up the active run:', e);
+      return null;
+    }
+  };
+
+  return {
+    async create(
+      projectId: string,
+      data: CreateAIRunData,
+    ): Promise<CreateAIRunResult> {
+      try {
+        const run = await clients.projects.createAIRun({
+          projectId,
+          createAIRunRequest: toClientCreateRequest(data),
+        });
+        return { status: 'created', run: toAIRun(run) };
+      } catch (e) {
+        // 1プロジェクトにつき同時に走れる Run は1本だけ。2本目は 409 になる。
+        // このエンドポイントには @ApiConflictResponse が付いていないため生成
+        // クライアントの型に 409 が現れない。ここで結果の型へ明示的に落とす。
+        if (e instanceof ResponseError && e.response.status === 409) {
+          return {
+            status: 'conflict',
+            message: await readErrorMessage(
+              e.response,
+              CONFLICT_FALLBACK_MESSAGE,
+            ),
+            runningRun: await findActiveRun(projectId),
+          };
+        }
+        throw e;
+      }
+    },
+
+    async list(projectId: string): Promise<AIRun[]> {
+      const runs = await clients.projects.getAIRuns({ projectId });
+      return runs.map(toAIRun);
+    },
+
+    async get(runId: string): Promise<AIRun> {
+      const run = await clients.runs.getAIRun({ runId });
+      return toAIRun(run);
+    },
+
+    getMessages(runId: string): Promise<AIMessage[]> {
+      return fetchMessages(runId);
+    },
+
+    async stop(runId: string): Promise<AIRun> {
+      const run = await clients.runs.stopAIRun({ runId });
+      return toAIRun(run);
+    },
+
+    subscribe(
+      runId: string,
+      options?: AIRunSubscribeOptions,
+    ): ReadableStream<AIRunStreamChunk> {
+      return createDurableRunStream(
+        {
+          fetchMessages: () => fetchMessages(runId),
+          openSSE: async () => {
+            const opts = await clients.runs.streamAIRunRequestOpts({ runId });
+            return fetchSSE(clients.configuration, opts);
+          },
+        },
+        options,
+      );
+    },
+  };
+}

--- a/packages/adapter/api/src/client.ts
+++ b/packages/adapter/api/src/client.ts
@@ -6,6 +6,7 @@ import {
   MemosApi,
   WritingsApi,
   AiApi,
+  AiRunsApi,
   AuthApi,
   NodesApi,
   ConsistencyApi,
@@ -23,6 +24,8 @@ export interface ApiClients {
   readonly memos: MemosApi;
   readonly writings: WritingsApi;
   readonly ai: AiApi;
+  /** 自律Run（`/v1/ai/runs/*`）。Run の作成・一覧は projects 側にある */
+  readonly runs: AiRunsApi;
   readonly consistency: ConsistencyApi;
   readonly glossary: GlossaryApi;
   readonly instructions: InstructionsApi;
@@ -46,6 +49,7 @@ export function createApiClients(
     memos: new MemosApi(configuration),
     writings: new WritingsApi(configuration),
     ai: new AiApi(configuration),
+    runs: new AiRunsApi(configuration),
     consistency: new ConsistencyApi(configuration),
     glossary: new GlossaryApi(configuration),
     instructions: new InstructionsApi(configuration),

--- a/packages/adapter/api/src/internal/helpers/message.ts
+++ b/packages/adapter/api/src/internal/helpers/message.ts
@@ -1,0 +1,66 @@
+import type { AIMessage as ClientAIMessage } from '@tsumugi-chan/client';
+import type {
+  AIMessage,
+  AIProposalMessage,
+  AITextMessage,
+  AIToolCallMessage,
+  AIToolResultMessage,
+} from '@tsumugi/adapter';
+import { toAIProposal } from './sse';
+
+/**
+ * バックエンドのメッセージ（生成クライアント型）を adapter-core の AIMessage に変換する。
+ *
+ * 対話チャットのセッションと自律Run の transcript で同じ形式が返るため共用する。
+ */
+export function toMessage(api: ClientAIMessage): AIMessage {
+  const role = api.role;
+  const messageType = api.messageType;
+  const base = {
+    id: api.id,
+    sessionId: api.sessionId,
+    role,
+  };
+
+  switch (messageType) {
+    case 'text': {
+      const textContent = api.content
+        .filter((c) => c.type === 'text')
+        .map((c) => c.text)
+        .join('');
+      return {
+        ...base,
+        messageType: 'text',
+        content: textContent,
+      } satisfies AITextMessage;
+    }
+    case 'tool_call': {
+      return {
+        ...base,
+        messageType: 'tool_call',
+        content: JSON.stringify(api.content),
+      } satisfies AIToolCallMessage;
+    }
+    // tool_result / feedback は LLM ↔ アダプター間・フロント→AI 間の内部メッセージ。
+    // UI には表示しない（buildDisplayMessages が text / proposal のみ表示）ため
+    // tool_result として畳み込む。
+    case 'tool_result':
+    case 'feedback': {
+      return {
+        ...base,
+        messageType: 'tool_result',
+        content: JSON.stringify(api.content),
+      } satisfies AIToolResultMessage;
+    }
+    case 'proposal': {
+      if (api.proposal) {
+        return {
+          ...base,
+          messageType: 'proposal',
+          proposal: toAIProposal(api.proposal),
+        } satisfies AIProposalMessage;
+      }
+    }
+  }
+  return { ...base, messageType: 'text', content: '' };
+}

--- a/packages/adapter/api/src/internal/helpers/run.spec.ts
+++ b/packages/adapter/api/src/internal/helpers/run.spec.ts
@@ -1,0 +1,405 @@
+import type { AIMessage, AIRunStreamChunk } from '@tsumugi/adapter';
+import {
+  createDurableRunStream,
+  isTerminalRunChunk,
+  toAIRunFinishReason,
+  toAIRunStreamChunk,
+  type RunStreamTransport,
+} from './run';
+
+/** SSE フレーム列を Response に組み立てる */
+function sseResponse(...frames: string[]): Response {
+  return new Response(frames.map((f) => `data: ${f}\n\n`).join(''));
+}
+
+/** 途中で切れた（終端チャンクなしで閉じた）SSE レスポンス */
+function truncatedResponse(...frames: string[]): Response {
+  return sseResponse(...frames);
+}
+
+async function drain(
+  stream: ReadableStream<AIRunStreamChunk>,
+): Promise<AIRunStreamChunk[]> {
+  const reader = stream.getReader();
+  const chunks: AIRunStreamChunk[] = [];
+  let r = await reader.read();
+  while (!r.done) {
+    chunks.push(r.value);
+    r = await reader.read();
+  }
+  return chunks;
+}
+
+const RUNNING = '{"type":"run-status","status":"running"}';
+const EMPTY_PLAN = '{"type":"plan","plan":[]}';
+const COMPLETED =
+  '{"type":"run-status","status":"completed","finish_reason":"completed_plan"}';
+
+function messageFixture(id: string): AIMessage {
+  return {
+    id,
+    sessionId: 's1',
+    role: 'assistant',
+    messageType: 'text',
+    content: id,
+  };
+}
+
+/** transcript と SSE レスポンスを順番に返すだけの transport */
+function stubTransport(
+  responses: (() => Response | Promise<Response>)[],
+  messages: AIMessage[][] = [],
+): RunStreamTransport & { sseCalls: number; messageCalls: number } {
+  const transport = {
+    sseCalls: 0,
+    messageCalls: 0,
+    async fetchMessages(): Promise<AIMessage[]> {
+      const index = transport.messageCalls;
+      transport.messageCalls += 1;
+      return messages[index] ?? [];
+    },
+    async openSSE(): Promise<Response> {
+      const factory = responses[transport.sseCalls];
+      transport.sseCalls += 1;
+      if (!factory) throw new Error('no more responses');
+      return factory();
+    },
+  };
+  return transport;
+}
+
+/** テストでは待機しない */
+const noSleep = () => Promise.resolve();
+
+describe('toAIRunFinishReason', () => {
+  it('既知の終了理由はそのまま返す', () => {
+    expect(toAIRunFinishReason('max_steps')).toBe('max_steps');
+    expect(toAIRunFinishReason('interrupted')).toBe('interrupted');
+  });
+
+  it('null / undefined は null を返す', () => {
+    expect(toAIRunFinishReason(null)).toBeNull();
+    expect(toAIRunFinishReason(undefined)).toBeNull();
+  });
+
+  it('未知の値は null を返す（将来の追加値で落ちない）', () => {
+    expect(toAIRunFinishReason('something_new')).toBeNull();
+  });
+});
+
+describe('toAIRunStreamChunk', () => {
+  it('run-status を正規化する（finish_reason なし）', () => {
+    expect(toAIRunStreamChunk(JSON.parse(RUNNING))).toEqual({
+      type: 'run_status',
+      status: 'running',
+    });
+  });
+
+  it('run-status の finish_reason を正規化する', () => {
+    expect(toAIRunStreamChunk(JSON.parse(COMPLETED))).toEqual({
+      type: 'run_status',
+      status: 'completed',
+      finishReason: 'completed_plan',
+    });
+  });
+
+  it('plan を content / active_form 付きで正規化する', () => {
+    const raw = JSON.parse(
+      '{"type":"plan","plan":[{"id":"r1-plan-0","content":"章を書く","active_form":"章を書いています","status":"in_progress"}]}',
+    );
+    expect(toAIRunStreamChunk(raw)).toEqual({
+      type: 'plan',
+      plan: [
+        {
+          id: 'r1-plan-0',
+          content: '章を書く',
+          activeForm: '章を書いています',
+          status: 'in_progress',
+        },
+      ],
+    });
+  });
+
+  it('text-delta を text に正規化する', () => {
+    const raw = JSON.parse('{"type":"text-delta","delta":"こんにちは"}');
+    expect(toAIRunStreamChunk(raw)).toEqual({
+      type: 'text',
+      content: 'こんにちは',
+    });
+  });
+
+  it('proposal-result から作成済みノードIDを取り出す', () => {
+    const raw = JSON.parse(
+      '{"type":"proposal-result","result":{"feedback":{"tool_call_id":"call_1","status":"accepted","content_type":"writing","target_id":"writing_9"},"has_stream":false}}',
+    );
+    expect(toAIRunStreamChunk(raw)).toEqual({
+      type: 'proposal_result',
+      proposalFeedback: {
+        toolCallId: 'call_1',
+        status: 'accepted',
+        contentType: 'writing',
+        targetId: 'writing_9',
+        conflictDetails: undefined,
+      },
+    });
+  });
+
+  it('error を非終端のチャンクとして返す', () => {
+    const raw = JSON.parse('{"type":"error","error":"一時的な失敗"}');
+    const chunk = toAIRunStreamChunk(raw);
+    expect(chunk).toEqual({ type: 'error', error: '一時的な失敗' });
+    expect(chunk && isTerminalRunChunk(chunk)).toBe(false);
+  });
+
+  it('Run では流れない finish / start は null を返す', () => {
+    expect(
+      toAIRunStreamChunk(JSON.parse('{"type":"finish","message_id":null}')),
+    ).toBeNull();
+    expect(toAIRunStreamChunk(JSON.parse('{"type":"start"}'))).toBeNull();
+  });
+
+  it('未知の type は null を返して読み飛ばす', () => {
+    expect(toAIRunStreamChunk(JSON.parse('{"type":"brand-new"}'))).toBeNull();
+  });
+
+  it('type を持たないペイロードは throw する', () => {
+    expect(() => toAIRunStreamChunk({ foo: 1 })).toThrow();
+  });
+});
+
+describe('isTerminalRunChunk', () => {
+  it('finishReason 付きの run_status のみ終端とみなす', () => {
+    expect(
+      isTerminalRunChunk({
+        type: 'run_status',
+        status: 'completed',
+        finishReason: 'max_steps',
+      }),
+    ).toBe(true);
+    expect(isTerminalRunChunk({ type: 'run_status', status: 'running' })).toBe(
+      false,
+    );
+    expect(isTerminalRunChunk({ type: 'text', content: 'a' })).toBe(false);
+  });
+});
+
+describe('createDurableRunStream', () => {
+  it('購読開始時に transcript を先に流し、終端で閉じる', async () => {
+    const transport = stubTransport(
+      [() => sseResponse(RUNNING, EMPTY_PLAN, COMPLETED)],
+      [[messageFixture('m1')]],
+    );
+
+    const chunks = await drain(
+      createDurableRunStream(transport, { sleep: noSleep }),
+    );
+
+    expect(chunks[0]).toEqual({
+      type: 'transcript',
+      messages: [messageFixture('m1')],
+    });
+    expect(chunks.map((c) => c.type)).toEqual([
+      'transcript',
+      'run_status',
+      'plan',
+      'run_status',
+    ]);
+    expect(chunks.at(-1)).toEqual({
+      type: 'run_status',
+      status: 'completed',
+      finishReason: 'completed_plan',
+    });
+    // 終端に達したので再接続しない
+    expect(transport.sseCalls).toBe(1);
+  });
+
+  it('終端前に閉じたら transcript を取り直してから再購読する', async () => {
+    const transport = stubTransport(
+      [
+        () =>
+          truncatedResponse(
+            RUNNING,
+            EMPTY_PLAN,
+            '{"type":"text-delta","delta":"途中"}',
+          ),
+        () => sseResponse(RUNNING, EMPTY_PLAN, COMPLETED),
+      ],
+      [[messageFixture('m1')], [messageFixture('m1'), messageFixture('m2')]],
+    );
+
+    const chunks = await drain(
+      createDurableRunStream(transport, {
+        sleep: noSleep,
+        reconnectDelaysMs: [5],
+      }),
+    );
+
+    expect(chunks.map((c) => c.type)).toEqual([
+      'transcript',
+      'run_status',
+      'plan',
+      'text',
+      'reconnecting',
+      // 再接続時は必ず transcript を取り直す（SSE はリプレイしないため）
+      'transcript',
+      'run_status',
+      'plan',
+      'run_status',
+    ]);
+    expect(chunks[4]).toEqual({ type: 'reconnecting', reconnectDelayMs: 5 });
+    expect(chunks[5]).toEqual({
+      type: 'transcript',
+      messages: [messageFixture('m1'), messageFixture('m2')],
+    });
+    expect(transport.messageCalls).toBe(2);
+  });
+
+  it('error チャンクは終端ではなく、後続の処理を続ける', async () => {
+    const transport = stubTransport([
+      () =>
+        sseResponse(
+          RUNNING,
+          EMPTY_PLAN,
+          '{"type":"error","error":"一時的な失敗"}',
+          '{"type":"text-delta","delta":"リトライ後"}',
+          COMPLETED,
+        ),
+    ]);
+
+    const chunks = await drain(
+      createDurableRunStream(transport, { sleep: noSleep }),
+    );
+
+    expect(chunks.map((c) => c.type)).toEqual([
+      'transcript',
+      'run_status',
+      'plan',
+      'error',
+      'text',
+      'run_status',
+    ]);
+    // error 後に再接続していない
+    expect(transport.sseCalls).toBe(1);
+  });
+
+  it('SSE の取得自体が失敗しても再接続する', async () => {
+    const transport = stubTransport([
+      () => {
+        throw new Error('network down');
+      },
+      () => sseResponse(RUNNING, EMPTY_PLAN, COMPLETED),
+    ]);
+
+    const chunks = await drain(
+      createDurableRunStream(transport, {
+        sleep: noSleep,
+        reconnectDelaysMs: [1],
+      }),
+    );
+
+    expect(chunks.map((c) => c.type)).toEqual([
+      'transcript',
+      'reconnecting',
+      'transcript',
+      'run_status',
+      'plan',
+      'run_status',
+    ]);
+  });
+
+  it('再接続の待機時間はバックオフし、末尾の値で頭打ちになる', async () => {
+    const slept: number[] = [];
+    const transport = stubTransport([
+      () => truncatedResponse(RUNNING, EMPTY_PLAN),
+      () => truncatedResponse(RUNNING, EMPTY_PLAN),
+      () => truncatedResponse(RUNNING, EMPTY_PLAN),
+      () => sseResponse(RUNNING, EMPTY_PLAN, COMPLETED),
+    ]);
+
+    await drain(
+      createDurableRunStream(transport, {
+        reconnectDelaysMs: [10, 20],
+        sleep: async (ms) => {
+          slept.push(ms);
+        },
+      }),
+    );
+
+    expect(slept).toEqual([10, 20, 20]);
+  });
+
+  it('スナップショットしか来ない場合は試行回数を使い切って error で閉じる', async () => {
+    // 常にスナップショットだけ返して閉じる = 接続が確立できていない扱い
+    const transport = stubTransport(
+      Array.from(
+        { length: 10 },
+        () => () => truncatedResponse(RUNNING, EMPTY_PLAN),
+      ),
+    );
+
+    const chunks = await drain(
+      createDurableRunStream(transport, {
+        sleep: noSleep,
+        maxReconnectAttempts: 2,
+        reconnectDelaysMs: [1],
+      }),
+    );
+
+    const last = chunks.at(-1);
+    expect(last?.type).toBe('error');
+    expect(last?.error).toContain('再接続できませんでした');
+    // 初回 + 再接続2回 = 3
+    expect(transport.sseCalls).toBe(3);
+  });
+
+  it('スナップショットより先に進めたら試行回数をリセットする', async () => {
+    // 毎回 1 チャンク余分に流してから切れる → 何度でも再接続する
+    const responses = Array.from(
+      { length: 5 },
+      () => () =>
+        truncatedResponse(
+          RUNNING,
+          EMPTY_PLAN,
+          '{"type":"text-delta","delta":"x"}',
+        ),
+    );
+    responses.push(() => sseResponse(RUNNING, EMPTY_PLAN, COMPLETED));
+
+    const transport = stubTransport(responses);
+
+    const chunks = await drain(
+      createDurableRunStream(transport, {
+        sleep: noSleep,
+        maxReconnectAttempts: 2,
+        reconnectDelaysMs: [1],
+      }),
+    );
+
+    // 上限 2 を超える 5 回の切断を挟んでも最後まで到達する
+    expect(transport.sseCalls).toBe(6);
+    expect(chunks.at(-1)).toEqual({
+      type: 'run_status',
+      status: 'completed',
+      finishReason: 'completed_plan',
+    });
+  });
+
+  it('消費側がキャンセルしたら再接続しない', async () => {
+    const transport = stubTransport([
+      () => truncatedResponse(RUNNING, EMPTY_PLAN),
+      () => sseResponse(RUNNING, EMPTY_PLAN, COMPLETED),
+    ]);
+
+    const stream = createDurableRunStream(transport, {
+      sleep: noSleep,
+      reconnectDelaysMs: [1],
+    });
+    const reader = stream.getReader();
+    await reader.read(); // transcript
+    await reader.cancel();
+
+    // キャンセル後に再購読が走っていないこと
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(transport.sseCalls).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/adapter/api/src/internal/helpers/run.spec.ts
+++ b/packages/adapter/api/src/internal/helpers/run.spec.ts
@@ -1,11 +1,13 @@
 import type { AIMessage, AIRunStreamChunk } from '@tsumugi/adapter';
 import {
   createDurableRunStream,
+  isNonRetryableStreamError,
   isTerminalRunChunk,
   toAIRunFinishReason,
   toAIRunStreamChunk,
   type RunStreamTransport,
 } from './run';
+import { SSEResponseError } from './sse';
 
 /** SSE フレーム列を Response に組み立てる */
 function sseResponse(...frames: string[]): Response {
@@ -183,6 +185,34 @@ describe('isTerminalRunChunk', () => {
   });
 });
 
+describe('isNonRetryableStreamError', () => {
+  it('再接続しても直らない 4xx を判定する', () => {
+    expect(
+      isNonRetryableStreamError(new SSEResponseError(404, 'Not Found')),
+    ).toBe(true);
+    expect(
+      isNonRetryableStreamError(new SSEResponseError(403, 'Forbidden')),
+    ).toBe(true);
+  });
+
+  it('一時的な失敗（401 / 429 / 5xx）は再接続対象とする', () => {
+    // 401 は購読のたびにトークンを取り直すためリフレッシュで回復しうる
+    expect(
+      isNonRetryableStreamError(new SSEResponseError(401, 'Unauthorized')),
+    ).toBe(false);
+    expect(
+      isNonRetryableStreamError(new SSEResponseError(429, 'Too Many Requests')),
+    ).toBe(false);
+    expect(
+      isNonRetryableStreamError(new SSEResponseError(503, 'Unavailable')),
+    ).toBe(false);
+  });
+
+  it('HTTP 由来でないエラーは再接続対象とする', () => {
+    expect(isNonRetryableStreamError(new Error('socket hang up'))).toBe(false);
+  });
+});
+
 describe('createDurableRunStream', () => {
   it('購読開始時に transcript を先に流し、終端で閉じる', async () => {
     const transport = stubTransport(
@@ -346,10 +376,72 @@ describe('createDurableRunStream', () => {
     );
 
     const last = chunks.at(-1);
-    expect(last?.type).toBe('error');
-    expect(last?.error).toContain('再接続できませんでした');
+    // 'error'（サーバーがリトライ中）ではなく 'disconnected'（打ち切り）で終わる
+    expect(last?.type).toBe('disconnected');
+    expect(last?.error).toContain('再接続を諦めました');
     // 初回 + 再接続2回 = 3
     expect(transport.sseCalls).toBe(3);
+  });
+
+  it('404 など再接続しても直らないエラーは即 disconnected で打ち切る', async () => {
+    const transport = stubTransport([
+      () => {
+        throw new SSEResponseError(404, 'Not Found');
+      },
+      () => sseResponse(RUNNING, EMPTY_PLAN, COMPLETED),
+    ]);
+
+    const chunks = await drain(
+      createDurableRunStream(transport, {
+        sleep: noSleep,
+        reconnectDelaysMs: [1],
+      }),
+    );
+
+    expect(chunks.map((c) => c.type)).toEqual(['transcript', 'disconnected']);
+    // リトライしていない
+    expect(transport.sseCalls).toBe(1);
+  });
+
+  it('500 は一時的な失敗として再接続する', async () => {
+    const transport = stubTransport([
+      () => {
+        throw new SSEResponseError(500, 'Internal Server Error');
+      },
+      () => sseResponse(RUNNING, EMPTY_PLAN, COMPLETED),
+    ]);
+
+    const chunks = await drain(
+      createDurableRunStream(transport, {
+        sleep: noSleep,
+        reconnectDelaysMs: [1],
+      }),
+    );
+
+    expect(chunks.map((c) => c.type)).toEqual([
+      'transcript',
+      'reconnecting',
+      'transcript',
+      'run_status',
+      'plan',
+      'run_status',
+    ]);
+  });
+
+  it('終端チャンクと同じ read に含まれた後続フレームを取りこぼさない', async () => {
+    // 終了済み Run の購読では run-status(終端) → plan が 1 回の read で届く
+    const transport = stubTransport([() => sseResponse(COMPLETED, EMPTY_PLAN)]);
+
+    const chunks = await drain(
+      createDurableRunStream(transport, { sleep: noSleep }),
+    );
+
+    expect(chunks.map((c) => c.type)).toEqual([
+      'transcript',
+      'run_status',
+      // 終端の後ろにあった plan も落とさない
+      'plan',
+    ]);
   });
 
   it('スナップショットより先に進めたら試行回数をリセットする', async () => {
@@ -382,6 +474,35 @@ describe('createDurableRunStream', () => {
       status: 'completed',
       finishReason: 'completed_plan',
     });
+  });
+
+  it('進捗があっても通算の再接続回数の上限で打ち切る（暴走の保険）', async () => {
+    // 毎回スナップショット + 1チャンク流してから切れる = attempt はリセットされ続ける。
+    // 通算上限が無いと永久に再接続してしまうケース。
+    const transport = stubTransport(
+      Array.from(
+        { length: 20 },
+        () => () =>
+          truncatedResponse(
+            RUNNING,
+            EMPTY_PLAN,
+            '{"type":"text-delta","delta":"x"}',
+          ),
+      ),
+    );
+
+    const chunks = await drain(
+      createDurableRunStream(transport, {
+        sleep: noSleep,
+        maxReconnectAttempts: 2,
+        maxTotalReconnects: 3,
+        reconnectDelaysMs: [1],
+      }),
+    );
+
+    expect(chunks.at(-1)?.type).toBe('disconnected');
+    // 初回 + 再接続3回 = 4 で打ち切られる
+    expect(transport.sseCalls).toBe(4);
   });
 
   it('消費側がキャンセルしたら再接続しない', async () => {

--- a/packages/adapter/api/src/internal/helpers/run.ts
+++ b/packages/adapter/api/src/internal/helpers/run.ts
@@ -1,0 +1,370 @@
+import {
+  ErrorStreamChunkFromJSON,
+  PlanStreamChunkFromJSON,
+  ProposalResultStreamChunkFromJSON,
+  ProposalStreamChunkFromJSON,
+  RunStatusStreamChunkFromJSON,
+  TextDeltaStreamChunkFromJSON,
+  ToolCallStreamChunkFromJSON,
+  ToolResultStreamChunkFromJSON,
+  UsageStreamChunkFromJSON,
+  type AIRun as ClientAIRun,
+  type PlanItem as ClientPlanItem,
+} from '@tsumugi-chan/client';
+import type {
+  AIMessage,
+  AIRun,
+  AIRunFinishReason,
+  AIRunPlanItem,
+  AIRunStreamChunk,
+  AIRunSubscribeOptions,
+  AIToolName,
+} from '@tsumugi/adapter';
+import {
+  hasType,
+  parseSSEFrame,
+  toAIProposal,
+  toProposalFeedback,
+} from './sse';
+
+// ─── 型変換 ───
+
+const AI_RUN_FINISH_REASONS: readonly AIRunFinishReason[] = [
+  'agent_completed',
+  'completed_plan',
+  'max_steps',
+  'max_tokens',
+  'node_limit',
+  'diminishing_returns',
+  'stopped',
+  'error',
+  'interrupted',
+];
+
+/**
+ * 終了理由が既知の値かどうかを判定する型ガード。
+ * バックエンドは `finish_reason` を string で返すため、ここで既知の値に絞り込む。
+ */
+function isAIRunFinishReason(value: string): value is AIRunFinishReason {
+  return (AI_RUN_FINISH_REASONS as readonly string[]).includes(value);
+}
+
+/**
+ * 終了理由（client → core）。未終了（null）と未知の値はどちらも null にする。
+ */
+export function toAIRunFinishReason(
+  value: string | null | undefined,
+): AIRunFinishReason | null {
+  if (value == null) return null;
+  return isAIRunFinishReason(value) ? value : null;
+}
+
+export function toAIRunPlanItem(api: ClientPlanItem): AIRunPlanItem {
+  return {
+    id: api.id,
+    content: api.content,
+    activeForm: api.activeForm,
+    status: api.status,
+  };
+}
+
+export function toAIRun(api: ClientAIRun): AIRun {
+  return {
+    id: api.id,
+    projectId: api.projectId,
+    status: api.status,
+    goal: api.goal,
+    plan: api.plan.map(toAIRunPlanItem),
+    finishReason: toAIRunFinishReason(api.finishReason),
+    model: api.model,
+    maxSteps: api.maxSteps,
+    stepCount: api.stepCount,
+    batchCount: api.batchCount,
+    maxTotalTokens: api.maxTotalTokens,
+    promptTokens: api.promptTokens,
+    completionTokens: api.completionTokens,
+    totalTokens: api.totalTokens,
+    createdNodeCount: api.createdNodeCount,
+    subagentCount: api.subagentCount,
+    lastError: api.lastError,
+    createdAt: api.createdAt,
+    updatedAt: api.updatedAt,
+  };
+}
+
+// ─── SSE チャンクの正規化 ───
+
+/**
+ * 自律Run の SSE チャンクを adapter-core の AIRunStreamChunk に正規化する。
+ *
+ * 対話チャットの `toAIStreamChunk` とは意図的に別実装にしている。
+ * - `plan` / `run-status` は Run にしか流れない
+ * - `error` は終端ではない（対話チャットと逆のセマンティクス）
+ * - `finish` / `start` は Run では流れない（来ても無視する）
+ *
+ * 未知の type は必ず null を返して読み飛ばす（default: throw / assertNever を足さないこと）。
+ * バックエンドはマイナーバージョンでチャンク種別を追加してくる。
+ */
+export function toAIRunStreamChunk(raw: unknown): AIRunStreamChunk | null {
+  if (!hasType(raw)) throw new Error('Invalid run SSE chunk');
+  switch (raw.type) {
+    case 'run-status': {
+      const chunk = RunStatusStreamChunkFromJSON(raw);
+      const finishReason = toAIRunFinishReason(chunk.finishReason);
+      return {
+        type: 'run_status',
+        status: chunk.status,
+        ...(finishReason !== null ? { finishReason } : {}),
+      };
+    }
+    case 'plan': {
+      const chunk = PlanStreamChunkFromJSON(raw);
+      return { type: 'plan', plan: chunk.plan.map(toAIRunPlanItem) };
+    }
+    case 'text-delta': {
+      const chunk = TextDeltaStreamChunkFromJSON(raw);
+      return { type: 'text', content: chunk.delta };
+    }
+    case 'tool-call': {
+      const chunk = ToolCallStreamChunkFromJSON(raw);
+      return {
+        type: 'tool_call',
+        toolCall: {
+          id: chunk.toolCallId,
+          name: chunk.toolName as AIToolName,
+          arguments: JSON.stringify(chunk.args),
+        },
+      };
+    }
+    case 'tool-result': {
+      const chunk = ToolResultStreamChunkFromJSON(raw);
+      return {
+        type: 'tool_result',
+        toolResult: {
+          toolCallId: chunk.toolCallId,
+          toolName: chunk.toolName as AIToolName,
+          result: JSON.stringify(chunk.result),
+        },
+      };
+    }
+    case 'proposal': {
+      const chunk = ProposalStreamChunkFromJSON(raw);
+      return { type: 'proposal', proposal: toAIProposal(chunk.proposal) };
+    }
+    case 'proposal-result': {
+      const chunk = ProposalResultStreamChunkFromJSON(raw);
+      return {
+        type: 'proposal_result',
+        proposalFeedback: toProposalFeedback(chunk.result.feedback),
+      };
+    }
+    case 'usage': {
+      const chunk = UsageStreamChunkFromJSON(raw);
+      return { type: 'usage', usage: chunk.usage };
+    }
+    case 'error': {
+      const chunk = ErrorStreamChunkFromJSON(raw);
+      return { type: 'error', error: chunk.error };
+    }
+    // Run では流れない / ドメインに現れないチャンク
+    case 'start':
+    case 'text-start':
+    case 'text-end':
+    case 'finish':
+      return null;
+  }
+  // 未知の type は握り潰してスキップする
+  return null;
+}
+
+/**
+ * 生の SSE フレーム（`data: <JSON>`）を 1 件パースして AIRunStreamChunk に変換する。
+ */
+export function parseAIRunSSEEvent(raw: string): AIRunStreamChunk | null {
+  return parseSSEFrame(raw, toAIRunStreamChunk);
+}
+
+/**
+ * 終端チャンクかどうか。
+ *
+ * Run には `finish` チャンクが流れないため、`run_status` かつ `finishReason` が
+ * 付いていることが唯一の終端条件。
+ */
+export function isTerminalRunChunk(chunk: AIRunStreamChunk): boolean {
+  return chunk.type === 'run_status' && chunk.finishReason != null;
+}
+
+// ─── 再接続付きストリーム ───
+
+/**
+ * 購読直後に必ず流れるスナップショット（`run-status` → `plan`）のチャンク数。
+ *
+ * 「再接続に進捗があったか」の判定に使う。スナップショットしか受け取れていない
+ * 場合は接続が確立できていないものとみなし、リトライ回数をリセットしない
+ * （無限再接続ループを防ぐ）。
+ */
+const SNAPSHOT_CHUNK_COUNT = 2;
+
+export const DEFAULT_RECONNECT_DELAYS_MS: readonly number[] = [
+  1000, 2000, 4000, 8000, 15000,
+];
+
+export const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10;
+
+/**
+ * 自律Run ストリームの入出力。テストで差し替えられるように切り出している。
+ */
+export interface RunStreamTransport {
+  /** transcript（メッセージ一覧）を取得する */
+  fetchMessages(): Promise<AIMessage[]>;
+  /** SSE レスポンスを取得する */
+  openSSE(): Promise<Response>;
+}
+
+export interface DurableRunStreamOptions extends AIRunSubscribeOptions {
+  /** 待機処理（テスト用に差し替える） */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * 再接続付きの自律Run ストリームを生成する。
+ *
+ * SSE は過去チャンクをリプレイせず、`Last-Event-ID` による再開もできない。
+ * そのため接続のたびに **transcript を取得してから** SSE を購読し、
+ * `transcript` チャンクで受け取り側の状態を置き換えさせる。
+ *
+ * 終端（`run_status` + `finishReason`）を受け取るまでにストリームが閉じた場合は
+ * ネットワーク切断とみなし、バックオフしながら再購読する。
+ */
+export function createDurableRunStream(
+  transport: RunStreamTransport,
+  options: DurableRunStreamOptions = {},
+): ReadableStream<AIRunStreamChunk> {
+  const delays =
+    options.reconnectDelaysMs && options.reconnectDelaysMs.length > 0
+      ? options.reconnectDelaysMs
+      : DEFAULT_RECONNECT_DELAYS_MS;
+  const maxAttempts =
+    options.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
+  const sleep = options.sleep ?? defaultSleep;
+
+  let cancelled = false;
+  let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+  const cancelActiveReader = () => {
+    const reader = activeReader;
+    activeReader = null;
+    reader?.cancel().catch((e) => {
+      console.error('[adapter-api] Failed to cancel run SSE reader:', e);
+    });
+  };
+
+  return new ReadableStream<AIRunStreamChunk>({
+    start(controller) {
+      /** 消費側がキャンセルした後の close/enqueue は例外になるため包む */
+      const safeClose = () => {
+        try {
+          controller.close();
+        } catch {
+          // すでにクローズ済み
+        }
+      };
+
+      const pump = async (): Promise<void> => {
+        let attempt = 0;
+
+        while (!cancelled) {
+          // このセッションで受け取ったチャンク数（スナップショットを含む）
+          let chunkCount = 0;
+          let terminated = false;
+
+          try {
+            const messages = await transport.fetchMessages();
+            if (cancelled) break;
+            controller.enqueue({ type: 'transcript', messages });
+
+            const response = await transport.openSSE();
+            if (cancelled) break;
+
+            const body = response.body;
+            if (!body) throw new Error('No response body for run SSE');
+
+            const reader = body.getReader();
+            activeReader = reader;
+            const decoder = new TextDecoder();
+            let buffer = '';
+
+            const emit = (chunk: AIRunStreamChunk) => {
+              chunkCount += 1;
+              controller.enqueue(chunk);
+              if (isTerminalRunChunk(chunk)) terminated = true;
+            };
+
+            while (!cancelled && !terminated) {
+              const { done, value } = await reader.read();
+              if (done) {
+                // 末尾に残ったフレームを取りこぼさない
+                if (buffer.trim()) {
+                  const chunk = parseAIRunSSEEvent(buffer);
+                  if (chunk) emit(chunk);
+                }
+                break;
+              }
+
+              buffer += decoder.decode(value, { stream: true });
+              const parts = buffer.split('\n\n');
+              buffer = parts.pop() ?? '';
+
+              for (const part of parts) {
+                const chunk = parseAIRunSSEEvent(part);
+                if (chunk) emit(chunk);
+                if (terminated) break;
+              }
+            }
+
+            cancelActiveReader();
+
+            if (terminated || cancelled) break;
+          } catch {
+            cancelActiveReader();
+            if (cancelled) break;
+            // transcript 取得・購読・読み取りの失敗はすべて切断として扱う
+          }
+
+          // ─── 再接続 ───
+          // スナップショットより先に進めていれば接続は確立できていたと判断し、
+          // リトライ回数をリセットする（長時間 Run で試行回数を使い切らないため）
+          if (chunkCount > SNAPSHOT_CHUNK_COUNT) attempt = 0;
+          attempt += 1;
+
+          if (attempt > maxAttempts) {
+            controller.enqueue({
+              type: 'error',
+              error: `自律Runのストリームに再接続できませんでした（${maxAttempts}回試行）。状態は再読み込みで確認してください。`,
+            });
+            break;
+          }
+
+          const delay = delays[Math.min(attempt - 1, delays.length - 1)] ?? 0;
+          controller.enqueue({ type: 'reconnecting', reconnectDelayMs: delay });
+          await sleep(delay);
+        }
+
+        safeClose();
+      };
+
+      pump().catch((e) => {
+        console.error('[adapter-api] run SSE pump error:', e);
+        safeClose();
+      });
+    },
+    cancel() {
+      cancelled = true;
+      cancelActiveReader();
+    },
+  });
+}

--- a/packages/adapter/api/src/internal/helpers/run.ts
+++ b/packages/adapter/api/src/internal/helpers/run.ts
@@ -20,7 +20,9 @@ import type {
   AIRunSubscribeOptions,
   AIToolName,
 } from '@tsumugi/adapter';
+import { ResponseError } from '@tsumugi-chan/client';
 import {
+  SSEResponseError,
   hasType,
   parseSSEFrame,
   toAIProposal,
@@ -212,6 +214,13 @@ export const DEFAULT_RECONNECT_DELAYS_MS: readonly number[] = [
 export const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10;
 
 /**
+ * 進捗の有無に関わらない通算の再接続回数の上限（暴走の保険）。
+ *
+ * 長時間 Run では正常でも何度か切断されるため上限は高くとるが、無制限にはしない。
+ */
+export const DEFAULT_MAX_TOTAL_RECONNECTS = 200;
+
+/**
  * 自律Run ストリームの入出力。テストで差し替えられるように切り出している。
  */
 export interface RunStreamTransport {
@@ -221,7 +230,33 @@ export interface RunStreamTransport {
   openSSE(): Promise<Response>;
 }
 
+/**
+ * 再接続しても解消しない HTTP ステータス。
+ *
+ * 401 は含めない（購読のたびにトークンを取り直すためリフレッシュで回復しうる）。
+ * 408 / 429 / 5xx も一時的な失敗として再接続に任せる。
+ */
+const NON_RETRYABLE_STATUSES: readonly number[] = [400, 403, 404, 410, 422];
+
+/**
+ * 再接続しても無駄なエラーかどうかを判定する。
+ *
+ * 例: Run が削除済み（404）やプロジェクト違い（403）でリトライを繰り返すと、
+ * 無意味なリクエストを撒いたうえに「再接続失敗」という誤った文言になる。
+ */
+export function isNonRetryableStreamError(error: unknown): boolean {
+  if (error instanceof SSEResponseError) {
+    return NON_RETRYABLE_STATUSES.includes(error.status);
+  }
+  if (error instanceof ResponseError) {
+    return NON_RETRYABLE_STATUSES.includes(error.response.status);
+  }
+  return false;
+}
+
 export interface DurableRunStreamOptions extends AIRunSubscribeOptions {
+  /** 通算の再接続回数の上限（暴走の保険） */
+  maxTotalReconnects?: number;
   /** 待機処理（テスト用に差し替える） */
   sleep?: (ms: number) => Promise<void>;
 }
@@ -250,6 +285,8 @@ export function createDurableRunStream(
       : DEFAULT_RECONNECT_DELAYS_MS;
   const maxAttempts =
     options.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
+  const maxTotalReconnects =
+    options.maxTotalReconnects ?? DEFAULT_MAX_TOTAL_RECONNECTS;
   const sleep = options.sleep ?? defaultSleep;
 
   let cancelled = false;
@@ -275,7 +312,12 @@ export function createDurableRunStream(
       };
 
       const pump = async (): Promise<void> => {
+        // 連続失敗の回数（進捗があればリセットする）
         let attempt = 0;
+        // 進捗の有無に関わらない通算の再接続回数。
+        // 「スナップショットの少し先まで流してから毎回切れる」サーバー相手だと
+        // attempt がリセットされ続けて再接続が止まらなくなるため、その保険。
+        let totalReconnects = 0;
 
         while (!cancelled) {
           // このセッションで受け取ったチャンク数（スナップショットを含む）
@@ -288,7 +330,14 @@ export function createDurableRunStream(
             controller.enqueue({ type: 'transcript', messages });
 
             const response = await transport.openSSE();
-            if (cancelled) break;
+            if (cancelled) {
+              // 接続確立中にキャンセルされた場合、body を捨てないと
+              // サーバー側の SSE がタイムアウトまで開いたままになる
+              void response.body?.cancel().catch(() => {
+                // 後片付けなので失敗は無視する
+              });
+              break;
+            }
 
             const body = response.body;
             if (!body) throw new Error('No response body for run SSE');
@@ -299,6 +348,10 @@ export function createDurableRunStream(
             let buffer = '';
 
             const emit = (chunk: AIRunStreamChunk) => {
+              // read() の待機中にキャンセルされていることがある。クローズ済みの
+              // controller に enqueue すると throw するため、通常の購読終了を
+              // 例外フローに乗せないようここで弾く。
+              if (cancelled) return;
               chunkCount += 1;
               controller.enqueue(chunk);
               if (isTerminalRunChunk(chunk)) terminated = true;
@@ -319,20 +372,32 @@ export function createDurableRunStream(
               const parts = buffer.split('\n\n');
               buffer = parts.pop() ?? '';
 
+              // 終端チャンクと同じ read に含まれた後続フレームを取りこぼさないよう、
+              // ここでは break せず parts を出し切る（スナップショットの
+              // run-status → plan が 1 回の read に収まるため、終了済み Run の
+              // 購読で plan を失わないようにする）
               for (const part of parts) {
                 const chunk = parseAIRunSSEEvent(part);
                 if (chunk) emit(chunk);
-                if (terminated) break;
               }
             }
 
             cancelActiveReader();
 
             if (terminated || cancelled) break;
-          } catch {
+          } catch (e) {
             cancelActiveReader();
             if (cancelled) break;
-            // transcript 取得・購読・読み取りの失敗はすべて切断として扱う
+            // 再接続しても直らないエラー（Run 削除済み・権限違い等）は即座に打ち切る。
+            // ここで諦めないと無意味なリクエストを撒いた末に誤った文言になる。
+            if (isNonRetryableStreamError(e)) {
+              controller.enqueue({
+                type: 'disconnected',
+                error: e instanceof Error ? e.message : String(e),
+              });
+              break;
+            }
+            // それ以外（transcript 取得・購読・読み取りの失敗）は切断として扱う
           }
 
           // ─── 再接続 ───
@@ -340,11 +405,15 @@ export function createDurableRunStream(
           // リトライ回数をリセットする（長時間 Run で試行回数を使い切らないため）
           if (chunkCount > SNAPSHOT_CHUNK_COUNT) attempt = 0;
           attempt += 1;
+          totalReconnects += 1;
 
-          if (attempt > maxAttempts) {
+          if (attempt > maxAttempts || totalReconnects > maxTotalReconnects) {
+            // 'error' ではなく 'disconnected'。'error' は「サーバーがリトライ中」を
+            // 意味するので、クライアント側の打ち切りと混ぜると UI が嘘をつく。
             controller.enqueue({
-              type: 'error',
-              error: `自律Runのストリームに再接続できませんでした（${maxAttempts}回試行）。状態は再読み込みで確認してください。`,
+              type: 'disconnected',
+              error:
+                'ストリームへの再接続を諦めました。進捗はここで止まって見えますが、実行自体は続いている可能性があります。',
             });
             break;
           }

--- a/packages/adapter/api/src/internal/helpers/sse.ts
+++ b/packages/adapter/api/src/internal/helpers/sse.ts
@@ -8,9 +8,13 @@ import {
   ToolResultStreamChunkFromJSON,
   UsageStreamChunkFromJSON,
 } from '@tsumugi-chan/client';
-import type { Proposal } from '@tsumugi-chan/client';
+import type {
+  Proposal,
+  AIProposalFeedback as ClientAIProposalFeedback,
+} from '@tsumugi-chan/client';
 import {
   AIProposal,
+  AIProposalFeedback,
   AIStreamChunk,
   AIToolName,
   FieldChange,
@@ -53,7 +57,7 @@ export async function fetchSSE(
  * 生の SSE フレーム（`data: <JSON>`）を 1 件パースし、変換関数で任意のチャンク型に変換する。
  * data 行が無い / 不正な JSON の場合は null を返す。
  */
-function parseSSEFrame<T>(
+export function parseSSEFrame<T>(
   raw: string,
   toChunk: (data: unknown) => T | null,
 ): T | null {
@@ -195,6 +199,22 @@ export function toAIProposal(proposal: Proposal): AIProposal {
     targetName: proposal.targetName,
     status: proposal.proposalStatus,
     diffs,
+  };
+}
+
+/**
+ * 提案の適用結果（生成クライアント型）を adapter-core の AIProposalFeedback に変換する。
+ * 対話チャットの承認/拒否レスポンスと自律Run の proposal-result チャンクで共用する。
+ */
+export function toProposalFeedback(
+  feedback: ClientAIProposalFeedback,
+): AIProposalFeedback {
+  return {
+    toolCallId: feedback.toolCallId,
+    status: feedback.status,
+    contentType: feedback.contentType,
+    targetId: feedback.targetId,
+    conflictDetails: feedback.conflictDetails,
   };
 }
 

--- a/packages/adapter/api/src/internal/helpers/sse.ts
+++ b/packages/adapter/api/src/internal/helpers/sse.ts
@@ -21,6 +21,22 @@ import {
 } from '@tsumugi/adapter';
 
 /**
+ * SSE リクエストが HTTP エラーになったことを表すエラー。
+ *
+ * `status` を保持するため、呼び出し側が「リトライして意味があるか」を判断できる
+ * （例: 404 は再接続しても直らない）。
+ */
+export class SSEResponseError extends Error {
+  readonly status: number;
+
+  constructor(status: number, statusText: string) {
+    super(`SSE request failed: ${status} ${statusText}`);
+    this.name = 'SSEResponseError';
+    this.status = status;
+  }
+}
+
+/**
  * RequestOpts から SSE リクエストを発行する
  */
 export async function fetchSSE(
@@ -45,9 +61,7 @@ export async function fetchSSE(
   });
 
   if (!response.ok) {
-    throw new Error(
-      `SSE request failed: ${response.status} ${response.statusText}`,
-    );
+    throw new SSEResponseError(response.status, response.statusText);
   }
 
   return response;

--- a/packages/adapter/core/src/adapter.ts
+++ b/packages/adapter/core/src/adapter.ts
@@ -20,6 +20,10 @@ import type {
   AIMemory,
   AIProjectUsage,
   AIContextPack,
+  AIRun,
+  AIRunStreamChunk,
+  CreateAIRunData,
+  CreateAIRunResult,
   ConsistencyCheck,
   ConsistencyCheckSummary,
   ConsistencyFinding,
@@ -211,6 +215,86 @@ export interface AIAdapter {
 }
 
 /**
+ * 自律Run 購読時のオプション
+ */
+export interface AIRunSubscribeOptions {
+  /**
+   * 終端に達する前に切断された場合の再接続試行回数の上限。
+   * 既定は adapter 実装依存。
+   */
+  maxReconnectAttempts?: number;
+  /**
+   * 再接続までの待機時間（ミリ秒）の列。
+   * n 回目の再接続では `reconnectDelaysMs[n - 1]`（範囲外なら末尾の値）を待つ。
+   */
+  reconnectDelaysMs?: number[];
+}
+
+/**
+ * 自律エージェント Run 操作のインターフェース
+ *
+ * 対話チャット（{@link AIAdapter}）とは別系統。AI が自分で計画を立てて
+ * 複数ステップを自動実行する。
+ */
+export interface AIRunAdapter {
+  /**
+   * 自律Run を作成して起動する。
+   *
+   * 1プロジェクトにつき同時に走れる Run は1本だけ。既に進行中の Run がある場合は
+   * throw せず `{ status: 'conflict' }` を返すので、必ず `status` で分岐して
+   * 進行中 Run への導線を出すこと。
+   */
+  create(projectId: string, data: CreateAIRunData): Promise<CreateAIRunResult>;
+
+  /**
+   * プロジェクトの自律Run 一覧を取得する（新しい順）
+   */
+  list(projectId: string): Promise<AIRun[]>;
+
+  /**
+   * 自律Run の現在の状態を取得する。
+   * 進捗（step / トークン）の累積値はここから読む。
+   */
+  get(runId: string): Promise<AIRun>;
+
+  /**
+   * Run の transcript（メッセージ一覧）を取得する。
+   *
+   * SSE は過去チャンクをリプレイしないため、これが表示内容の正となる。
+   * 到着順に依存せず、提案とツール呼び出しの正しい順序はこの結果の順序に従う。
+   * バッチ境界（`usage` チャンク）や再接続のたびに取り直すとよい。
+   */
+  getMessages(runId: string): Promise<AIMessage[]>;
+
+  /**
+   * 自律Run を停止する（冪等）。
+   *
+   * 停止は現在のバッチ終了後に確定するため、**戻り値の `status` はまだ
+   * `running` のことがある。** これをそのまま「停止済み」として UI に反映しないこと。
+   * 確定は購読ストリームの `run_status`（`finishReason: 'stopped'`）で検知する。
+   */
+  stop(runId: string): Promise<AIRun>;
+
+  /**
+   * 自律Run を購読する。
+   *
+   * 実行中・終了済みのどちらでも購読できる（途中参加可）。返すストリームは
+   * 切断時の再接続まで面倒をみるため、受け取り側は届いたチャンクを
+   * 反映するだけでよい。
+   *
+   * - 購読開始時と再接続時に `transcript` チャンクが流れる。
+   *   SSE は過去チャンクをリプレイしないため、これでメッセージ状態を**置き換える**
+   * - 終端は `run_status` かつ `finishReason` が付いたチャンク。
+   *   ストリームはその後クローズされる
+   * - `error` チャンクは終端ではない（バックエンドが最大2回リトライする）
+   */
+  subscribe(
+    runId: string,
+    options?: AIRunSubscribeOptions,
+  ): ReadableStream<AIRunStreamChunk>;
+}
+
+/**
  * ノードのAI属性
  * 未指定（undefined）のフィールドは「変更しない」を意味する。
  */
@@ -357,6 +441,7 @@ export interface Adapter {
   readonly memos: MemoAdapter;
   readonly writings: WritingAdapter;
   readonly ai: AIAdapter;
+  readonly runs: AIRunAdapter;
   readonly consistency: ConsistencyAdapter;
   readonly glossary: GlossaryAdapter;
   readonly instructions: InstructionAdapter;

--- a/packages/adapter/core/src/stub.ts
+++ b/packages/adapter/core/src/stub.ts
@@ -90,6 +90,14 @@ export function createAdapter(_: AdapterConfig = {}): Adapter {
       getUsage: () => notImplemented(),
       getContext: () => notImplemented(),
     },
+    runs: {
+      create: () => notImplemented(),
+      list: () => notImplemented(),
+      get: () => notImplemented(),
+      getMessages: () => notImplemented(),
+      stop: () => notImplemented(),
+      subscribe: () => notImplemented(),
+    },
     consistency: {
       run: () => notImplemented(),
       list: () => notImplemented(),

--- a/packages/adapter/core/src/types.ts
+++ b/packages/adapter/core/src/types.ts
@@ -716,7 +716,8 @@ export type AIRunStreamChunkType =
   | 'error'
   | 'plan'
   | 'run_status'
-  | 'reconnecting';
+  | 'reconnecting'
+  | 'disconnected';
 
 /**
  * 自律Run ストリームのチャンク
@@ -757,11 +758,15 @@ export interface AIRunStreamChunk {
   /** トークン使用量（type='usage'時）。**そのバッチ単体**の値で累積ではない */
   usage?: AITokenUsage;
   /**
-   * エラーメッセージ（type='error'時）。
+   * エラーメッセージ（type='error' / 'disconnected'時）。
    *
-   * **終端ではない。** バックエンドが最大2回リトライするため後続処理が続く
-   * （2秒 / 4秒の無音区間が発生する）。3回連続で失敗して初めて
-   * `run_status` の `error` になる。
+   * `type='error'` は **終端ではない。** バックエンドが最大2回リトライするため
+   * 後続処理が続く（2秒 / 4秒の無音区間が発生する）。3回連続で失敗して初めて
+   * `run_status` の `error` になる。したがって UI では「失敗」ではなく
+   * 「リトライ中」として見せること。
+   *
+   * `type='disconnected'` は逆に**クライアント側の打ち切り**で、以降チャンクは
+   * 流れない。両者を同じ扱いにしないこと。
    */
   error?: string;
   /** 現在の計画（type='plan'時、全項目） */
@@ -778,6 +783,7 @@ export interface AIRunStreamChunk {
    * 再接続までの待機ミリ秒（type='reconnecting'時）。
    *
    * 終端 `run_status` を受け取る前にストリームが閉じた場合に流れる。
+   * この後 `transcript` が流れれば再接続成功、`disconnected` が流れれば打ち切り。
    */
   reconnectDelayMs?: number;
 }

--- a/packages/adapter/core/src/types.ts
+++ b/packages/adapter/core/src/types.ts
@@ -542,6 +542,246 @@ export interface AIChatMessageRequest extends AIChatRequestBase {
  */
 export type AIChatRequest = AIChatMessageRequest;
 
+// ─── 自律エージェント Run ───
+
+/**
+ * 自律Run のステータス
+ *
+ * `paused` は型上存在するが現状どこからも遷移しない（将来用の予約）。
+ *
+ * **`completed` は「成功」を意味しない。** ステップ/トークン上限による打ち切りも
+ * `completed` になるため、ユーザーへの文言は必ず {@link AIRunFinishReason} で出し分ける。
+ */
+export type AIRunStatus =
+  | 'queued'
+  | 'running'
+  | 'paused'
+  | 'completed'
+  | 'stopped'
+  | 'error';
+
+/**
+ * 自律Run の終了理由
+ *
+ * `status` だけでは成否が判別できないため、UI 文言はこの値で決める。
+ * - `agent_completed` / `completed_plan`: 成功
+ * - `max_steps` / `max_tokens` / `node_limit` / `diminishing_returns`: 打ち切り（続きがある）
+ * - `stopped`: ユーザーによる停止
+ * - `error`: エラー（`lastError` を表示する）
+ * - `interrupted`: サーバー再起動等による中断。**自動再開しない**ため再実行を促す
+ */
+export type AIRunFinishReason =
+  | 'agent_completed'
+  | 'completed_plan'
+  | 'max_steps'
+  | 'max_tokens'
+  | 'node_limit'
+  | 'diminishing_returns'
+  | 'stopped'
+  | 'error'
+  | 'interrupted';
+
+/**
+ * 計画項目の状態
+ */
+export type AIRunPlanItemStatus = 'pending' | 'in_progress' | 'completed';
+
+/**
+ * 自律Run の計画項目
+ */
+export interface AIRunPlanItem {
+  /**
+   * 計画項目ID。
+   *
+   * **React の key など安定キーには使わないこと。** 実体は `${runId}-plan-${index}` の
+   * インデックス採番で、計画更新は全上書きのため項目が入れ替わると
+   * 同じ id が別内容を指す。
+   */
+  id: string;
+  /** 命令形の内容 */
+  content: string;
+  /** 進行形の表示（実行中の項目はこちらを表示する） */
+  activeForm: string;
+  /** 項目の状態 */
+  status: AIRunPlanItemStatus;
+}
+
+/**
+ * 自律エージェント Run
+ *
+ * AI が自分で計画を立て、複数ステップを自動実行する処理の1単位。
+ * 対話チャット（{@link AIChatSession}）とは別系統。
+ */
+export interface AIRun extends Timestamps {
+  id: string;
+  projectId: string;
+  /** ステータス（成否の判定には使えない。{@link finishReason} を見ること） */
+  status: AIRunStatus;
+  /** ユーザーが与えた自律ゴール */
+  goal: string;
+  /** 現在の計画（全項目） */
+  plan: AIRunPlanItem[];
+  /** 終了理由（未終了なら null） */
+  finishReason: AIRunFinishReason | null;
+  /** 使用モデル（未指定なら null = バックエンド既定） */
+  model: string | null;
+  /** Run 全体の step 総上限 */
+  maxSteps: number;
+  /** 実行済み step 数 */
+  stepCount: number;
+  /** 実行済みバッチ数 */
+  batchCount: number;
+  /** トークン予算（入力＋出力の合計。未指定時はサーバー既定値が入る） */
+  maxTotalTokens: number | null;
+  /** 累積プロンプト（入力）トークン */
+  promptTokens: number;
+  /** 累積生成（出力）トークン */
+  completionTokens: number;
+  /** 累積合計トークン（入力＋出力。進捗表示にはこれを使う） */
+  totalTokens: number;
+  /** この Run が生成したノード数 */
+  createdNodeCount: number;
+  /** 起動したサブエージェント数 */
+  subagentCount: number;
+  /** 最後のエラー（なければ null） */
+  lastError: string | null;
+}
+
+/**
+ * 自律Run の作成データ
+ */
+export interface CreateAIRunData {
+  /** AI に与える自律ゴール（1〜4000文字） */
+  goal: string;
+  /** 使用するモデル（未指定ならバックエンド既定） */
+  model?: string;
+  /** Run 全体の step 総上限（1〜200、未指定なら 60） */
+  maxSteps?: number;
+  /**
+   * トークン予算（1000〜5,000,000、未指定なら 2,000,000）。
+   *
+   * **出力だけでなく入力を含む合計。** 毎バッチでコンテキスト全文を再送するため
+   * 入力:出力は 10〜30:1 になり得る。UI では合計であることを明記する。
+   */
+  maxTotalTokens?: number;
+}
+
+/**
+ * 自律Run の作成結果（判別可能なユニオン）
+ *
+ * 同時実行の衝突は「起きて当然のユーザー向け状態」なので例外にせず、
+ * 結果の型で表現する。
+ *
+ * バックエンドの `createAIRun` には `@ApiConflictResponse` が付いていないため
+ * **生成された型付きクライアントに 409 が現れない**。型に出てこないと気づかず
+ * 握り潰してしまうため、ここで型として明示し、呼び出し側に `status` の分岐を
+ * 強制する。
+ */
+export type CreateAIRunResult =
+  | {
+      status: 'created';
+      run: AIRun;
+    }
+  | {
+      /**
+       * 同時実行の衝突（HTTP 409）。
+       *
+       * 1プロジェクトにつき同時に走れる Run は1本だけ。UI では
+       * `runningRun` への導線を出し、二重送信を抑止すること。
+       * サーバークラッシュ等で残った Run は10分後に自動回収されるため、
+       * 時間経過で解消することもある。
+       */
+      status: 'conflict';
+      /** バックエンドが返したメッセージ */
+      message: string;
+      /** 進行中の Run（取得できなかった場合は null） */
+      runningRun: AIRun | null;
+    };
+
+/**
+ * 自律Run ストリームのチャンク種別
+ *
+ * 対話チャット（{@link AIStreamChunk}）とはセマンティクスが異なる。
+ * - `done` / `finish` は流れない。終端は `run_status` かつ `finishReason` が付いたチャンク
+ * - `error` は終端ではない（バックエンドが最大2回リトライする）
+ */
+export type AIRunStreamChunkType =
+  | 'transcript'
+  | 'text'
+  | 'tool_call'
+  | 'tool_result'
+  | 'proposal'
+  | 'proposal_result'
+  | 'usage'
+  | 'error'
+  | 'plan'
+  | 'run_status'
+  | 'reconnecting';
+
+/**
+ * 自律Run ストリームのチャンク
+ *
+ * adapter-api がバックエンドの SSE を正規化し、さらに切断時の再購読までを
+ * 面倒みたうえでこの安定した形で流す。
+ */
+export interface AIRunStreamChunk {
+  type: AIRunStreamChunkType;
+  /**
+   * transcript 全体（type='transcript'時）。
+   *
+   * 購読開始時と再接続時に流れる。SSE は過去チャンクをリプレイしないため、
+   * 受け取り側はこのチャンクで**メッセージ状態を置き換える**（追記しない）。
+   */
+  messages?: AIMessage[];
+  /** テキストの増分（type='text'時） */
+  content?: string;
+  /** ツール呼び出し情報（type='tool_call'時） */
+  toolCall?: AIToolCall;
+  /** ツール実行結果（type='tool_result'時） */
+  toolResult?: { toolCallId: string; toolName: AIToolName; result: string };
+  /**
+   * AI変更提案（type='proposal'時）。
+   *
+   * 対応する tool_call より先に届くことがある。到着順に依存しないこと。
+   * 順序の正は transcript の順序。
+   */
+  proposal?: AIProposal;
+  /**
+   * 提案の適用結果（type='proposal_result'時）。
+   *
+   * 自律Run が作ったノードは `canonStatus: 'draft'` で**即座に保存済み**であり
+   * 「提案→承認」ではない。`targetId` が作成/更新されたノードID。
+   * これを受けたらツリーを再取得する。
+   */
+  proposalFeedback?: AIProposalFeedback;
+  /** トークン使用量（type='usage'時）。**そのバッチ単体**の値で累積ではない */
+  usage?: AITokenUsage;
+  /**
+   * エラーメッセージ（type='error'時）。
+   *
+   * **終端ではない。** バックエンドが最大2回リトライするため後続処理が続く
+   * （2秒 / 4秒の無音区間が発生する）。3回連続で失敗して初めて
+   * `run_status` の `error` になる。
+   */
+  error?: string;
+  /** 現在の計画（type='plan'時、全項目） */
+  plan?: AIRunPlanItem[];
+  /** Run のステータス（type='run_status'時） */
+  status?: AIRunStatus;
+  /**
+   * 終了理由（type='run_status'時、終了時のみ）。
+   *
+   * これが設定された `run_status` チャンクが**終端**。
+   */
+  finishReason?: AIRunFinishReason;
+  /**
+   * 再接続までの待機ミリ秒（type='reconnecting'時）。
+   *
+   * 終端 `run_status` を受け取る前にストリームが閉じた場合に流れる。
+   */
+  reconnectDelayMs?: number;
+}
+
 // ─── AIコンテキストプレビュー ───
 
 /**

--- a/packages/ui/src/components/features/ai-run-panel/ai-run-panel.stories.tsx
+++ b/packages/ui/src/components/features/ai-run-panel/ai-run-panel.stories.tsx
@@ -1,0 +1,273 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import * as React from 'react';
+import { AiRunPanel } from './ai-run-panel';
+import type {
+  AiRunDetail,
+  AiRunMessage,
+  AiRunStartInput,
+  AiRunSummary,
+} from './types';
+import type { AiModelOption } from '../ai-panel/ai-panel';
+
+const mockModels: AiModelOption[] = [
+  { value: 'gpt-5.4', label: 'GPT-5.4' },
+  { value: 'gpt-5.2', label: 'GPT-5.2' },
+  { value: 'gpt-4o-mini', label: 'GPT-4o mini' },
+  { value: 'claude-3-5-haiku-latest', label: 'Claude 3.5 Haiku' },
+];
+
+const mockRunningRun: AiRunDetail = {
+  id: 'run_1',
+  goal: '第2章のプロットを整理して、登場人物の設定と矛盾がないようにメモを作成する',
+  status: 'running',
+  finishReason: null,
+  plan: [
+    {
+      content: '第1章と第2章のプロットを読む',
+      activeForm: '第1章と第2章のプロットを読んでいます',
+      status: 'completed',
+    },
+    {
+      content: '登場人物の設定を確認する',
+      activeForm: '登場人物の設定を確認しています',
+      status: 'completed',
+    },
+    {
+      content: '矛盾点をメモにまとめる',
+      activeForm: '矛盾点をメモにまとめています',
+      status: 'in_progress',
+    },
+    {
+      content: '第2章のプロットを更新する',
+      activeForm: '第2章のプロットを更新しています',
+      status: 'pending',
+    },
+  ],
+  stepCount: 14,
+  maxSteps: 60,
+  totalTokens: 486_200,
+  maxTotalTokens: 2_000_000,
+  createdNodeCount: 2,
+  subagentCount: 1,
+  lastError: null,
+};
+
+const mockMessages: AiRunMessage[] = [
+  {
+    id: 'm1',
+    kind: 'text',
+    role: 'user',
+    content:
+      '第2章のプロットを整理して、登場人物の設定と矛盾がないようにメモを作成する',
+  },
+  {
+    id: 'm2',
+    kind: 'text',
+    role: 'assistant',
+    content:
+      '第1章と第2章のプロットを読みました。**時系列の矛盾**が2件見つかりました。\n\n1. 主人公が第1章で「まだ剣を握ったことがない」とありますが、第2章冒頭で熟練した剣技を見せています。\n2. 妹の年齢が第1章では12歳、第2章では15歳と書かれています。',
+  },
+  {
+    id: 'm3',
+    kind: 'edit',
+    action: 'create',
+    contentType: 'memo',
+    targetName: '第2章 矛盾点メモ',
+  },
+  {
+    id: 'm4',
+    kind: 'text',
+    role: 'assistant',
+    content: '矛盾点をメモにまとめました。続けてプロット側を修正します。',
+  },
+  {
+    id: 'm5',
+    kind: 'edit',
+    action: 'update',
+    contentType: 'plot',
+    targetName: '第2章 邂逅',
+  },
+];
+
+const mockRuns: AiRunSummary[] = [
+  {
+    id: 'run_1',
+    goal: '第2章のプロットを整理して、登場人物の設定と矛盾がないようにメモを作成する',
+    status: 'running',
+    finishReason: null,
+    createdAt: new Date('2026-08-04T10:30:00'),
+  },
+  {
+    id: 'run_2',
+    goal: '登場人物一覧を作る',
+    status: 'completed',
+    finishReason: 'agent_completed',
+    createdAt: new Date('2026-08-03T18:12:00'),
+  },
+  {
+    id: 'run_3',
+    goal: '全章のあらすじを書き出す',
+    status: 'completed',
+    finishReason: 'max_steps',
+    createdAt: new Date('2026-08-02T09:05:00'),
+  },
+  {
+    id: 'run_4',
+    goal: '世界観設定を膨らませる',
+    status: 'error',
+    finishReason: 'interrupted',
+    createdAt: new Date('2026-08-01T22:40:00'),
+  },
+];
+
+const meta = {
+  title: 'Features/AiRunPanel',
+  component: AiRunPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ height: '600px', width: '380px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AiRunPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    run: mockRunningRun,
+    messages: mockMessages,
+    runs: mockRuns,
+    models: mockModels,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    run: null,
+    runs: [],
+    models: mockModels,
+  },
+};
+
+/** ゴール入力から実行開始・停止までを state で再現する */
+export const Interactive: StoryObj = {
+  render: () => {
+    const [run, setRun] = React.useState<AiRunDetail | null>(null);
+    const [messages, setMessages] = React.useState<AiRunMessage[]>([]);
+    const [isStarting, setIsStarting] = React.useState(false);
+    const [isStopping, setIsStopping] = React.useState(false);
+
+    const handleStartRun = (input: AiRunStartInput) => {
+      setIsStarting(true);
+      // 起動リクエストを擬似的に待つ
+      setTimeout(() => {
+        setIsStarting(false);
+        setRun({
+          ...mockRunningRun,
+          goal: input.goal,
+          maxSteps: input.maxSteps,
+          maxTotalTokens: input.maxTotalTokens,
+          stepCount: 1,
+          totalTokens: 12_400,
+          createdNodeCount: 0,
+          subagentCount: 0,
+          plan: [],
+        });
+        setMessages([
+          { id: 'u1', kind: 'text', role: 'user', content: input.goal },
+        ]);
+      }, 600);
+    };
+
+    const handleStopRun = () => {
+      setIsStopping(true);
+      // 停止は現在のバッチ終了後に確定するため、少し遅れて反映される
+      setTimeout(() => {
+        setIsStopping(false);
+        setRun((prev) =>
+          prev ? { ...prev, status: 'stopped', finishReason: 'stopped' } : prev,
+        );
+      }, 1200);
+    };
+
+    return (
+      <AiRunPanel
+        run={run}
+        messages={messages}
+        runs={mockRuns}
+        models={mockModels}
+        isStarting={isStarting}
+        isStopping={isStopping}
+        onStartRun={handleStartRun}
+        onStopRun={handleStopRun}
+        onNewRun={() => {
+          setRun(null);
+          setMessages([]);
+        }}
+      />
+    );
+  },
+};
+
+/** ステップ上限で打ち切られた状態（status は completed だが成功ではない） */
+export const TruncatedByMaxSteps: Story = {
+  args: {
+    run: {
+      ...mockRunningRun,
+      status: 'completed',
+      finishReason: 'max_steps',
+      stepCount: 60,
+      plan: mockRunningRun.plan.map((item, index) =>
+        index < 2 ? { ...item, status: 'completed' } : item,
+      ),
+    },
+    messages: mockMessages,
+    runs: mockRuns,
+    models: mockModels,
+  },
+};
+
+/** サーバー再起動などで中断された状態（自動再開しない） */
+export const Interrupted: Story = {
+  args: {
+    run: {
+      ...mockRunningRun,
+      status: 'error',
+      finishReason: 'interrupted',
+      lastError: 'worker restarted while the run was in flight',
+    },
+    messages: mockMessages,
+    runs: mockRuns,
+    models: mockModels,
+  },
+};
+
+/** 同時実行の 409。進行中 Run への導線を出す */
+export const ConflictOnStart: Story = {
+  args: {
+    run: null,
+    runs: mockRuns,
+    models: mockModels,
+    startError: {
+      message: 'このプロジェクトでは既に自律実行が進行中です。',
+      runningRunId: 'run_1',
+    },
+  },
+};
+
+/** ストリーム切断からの再接続中 */
+export const Reconnecting: Story = {
+  args: {
+    run: mockRunningRun,
+    messages: mockMessages,
+    runs: mockRuns,
+    models: mockModels,
+    isReconnecting: true,
+    streamingContent: '',
+  },
+};

--- a/packages/ui/src/components/features/ai-run-panel/ai-run-panel.stories.tsx
+++ b/packages/ui/src/components/features/ai-run-panel/ai-run-panel.stories.tsx
@@ -73,6 +73,7 @@ const mockMessages: AiRunMessage[] = [
     action: 'create',
     contentType: 'memo',
     targetName: '第2章 矛盾点メモ',
+    status: 'accepted',
   },
   {
     id: 'm4',
@@ -86,6 +87,16 @@ const mockMessages: AiRunMessage[] = [
     action: 'update',
     contentType: 'plot',
     targetName: '第2章 邂逅',
+    status: 'accepted',
+  },
+  {
+    id: 'm6',
+    kind: 'edit',
+    action: 'update',
+    contentType: 'character',
+    // 編集保護（editPolicy: approval_required）で弾かれた例
+    targetName: '主人公 アキラ',
+    status: 'rejected',
   },
 ];
 
@@ -268,6 +279,52 @@ export const Reconnecting: Story = {
     runs: mockRuns,
     models: mockModels,
     isReconnecting: true,
-    streamingContent: '',
+  },
+};
+
+/** サーバー側がリトライ中（終端ではないので「失敗」と書かない） */
+export const RetryingAfterError: Story = {
+  args: {
+    run: mockRunningRun,
+    messages: mockMessages,
+    runs: mockRuns,
+    models: mockModels,
+    transientError: 'upstream timeout',
+  },
+};
+
+/** 再接続を諦めた状態（自動リトライとは別物として見せる） */
+export const Disconnected: Story = {
+  args: {
+    run: mockRunningRun,
+    messages: mockMessages,
+    runs: mockRuns,
+    models: mockModels,
+    fatalError:
+      'ストリームへの再接続を諦めました。進捗はここで止まって見えますが、実行自体は続いている可能性があります。',
+  },
+};
+
+/** 終了理由が未知（バックエンドが新しい値を追加した場合も成功と誤解させない） */
+export const UnknownFinishReason: Story = {
+  args: {
+    run: {
+      ...mockRunningRun,
+      status: 'completed',
+      finishReason: null,
+    },
+    messages: mockMessages,
+    runs: mockRuns,
+    models: mockModels,
+  },
+};
+
+/** Run の取得に失敗（黙って起動フォームに戻さない） */
+export const LoadFailed: Story = {
+  args: {
+    run: null,
+    runs: mockRuns,
+    models: mockModels,
+    loadError: '実行を読み込めませんでした: Not Found',
   },
 };

--- a/packages/ui/src/components/features/ai-run-panel/ai-run-panel.tsx
+++ b/packages/ui/src/components/features/ai-run-panel/ai-run-panel.tsx
@@ -40,8 +40,12 @@ export function AiRunPanel({
   isStopping = false,
   isReconnecting = false,
   transientError = null,
+  fatalError = null,
+  onRetryConnection,
+  loadError = null,
   startError = null,
   models = [],
+  initialGoal,
   goalMaxLength = 4000,
   maxStepsRange = DEFAULT_MAX_STEPS_RANGE,
   maxTotalTokensRange = DEFAULT_MAX_TOTAL_TOKENS_RANGE,
@@ -63,7 +67,8 @@ export function AiRunPanel({
             variant="ghost"
             size="sm"
             className="h-7 gap-1 px-2 text-xs"
-            onClick={onNewRun}
+            // 打ち切られた Run の続きを実行しやすいようゴールを引き継ぐ
+            onClick={() => onNewRun?.(run?.goal)}
           >
             <Plus className="size-3" />
             新しい実行
@@ -71,7 +76,21 @@ export function AiRunPanel({
         )}
       </div>
 
-      {run == null && isLoadingRun ? (
+      {run == null && loadError ? (
+        // 取得に失敗したときに黙って起動フォームへ落とすと、実行中でも
+        // 気づかず2本目を投げて 409 になるため、明示的にエラーを見せる
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 p-4 text-center">
+          <p className="text-xs text-destructive">{loadError}</p>
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            onClick={onRetryConnection}
+          >
+            再試行
+          </Button>
+        </div>
+      ) : run == null && isLoadingRun ? (
         <div className="flex flex-1 items-center justify-center gap-2 text-xs text-muted-foreground">
           <Loader2 className="size-3 animate-spin" />
           実行を読み込んでいます…
@@ -87,6 +106,7 @@ export function AiRunPanel({
             goalMaxLength={goalMaxLength}
             maxStepsRange={maxStepsRange}
             maxTotalTokensRange={maxTotalTokensRange}
+            initialGoal={initialGoal}
           />
         </ScrollArea>
       ) : (
@@ -97,8 +117,10 @@ export function AiRunPanel({
               <StatusBadge status={run.status} />
             </div>
 
-            {/* status だけでは成否が判別できないため、終了理由で文言を出し分ける */}
-            {run.finishReason && (
+            {/* status だけでは成否が判別できないため、終了理由で文言を出し分ける。
+                終了しているのに理由が未知の場合も必ずバナーを出す（黙って
+                「終了」だけ見せると成功と誤解されるため）。 */}
+            {!isActive && (
               <FinishBanner
                 finishReason={run.finishReason}
                 lastError={run.lastError}
@@ -112,8 +134,23 @@ export function AiRunPanel({
               </p>
             )}
 
+            {/* 購読の打ち切り。自動リトライされる error とは別物として見せる */}
+            {fatalError && (
+              <div className="space-y-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2">
+                <p className="text-xs text-destructive">{fatalError}</p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  onClick={onRetryConnection}
+                >
+                  再接続する
+                </Button>
+              </div>
+            )}
+
             {/* error チャンクは終端ではなく自動リトライされるため、失敗とは書かない */}
-            {transientError && !run.finishReason && (
+            {transientError && !fatalError && isActive && (
               <p className="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-300">
                 <AlertTriangle className="mt-0.5 size-3 shrink-0" />
                 <span className="min-w-0 break-words">

--- a/packages/ui/src/components/features/ai-run-panel/ai-run-panel.tsx
+++ b/packages/ui/src/components/features/ai-run-panel/ai-run-panel.tsx
@@ -1,0 +1,186 @@
+import { AlertTriangle, Loader2, Plus, RefreshCw, Square } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
+import type { AiRunPanelProps } from './types';
+import {
+  DEFAULT_MAX_STEPS_RANGE,
+  DEFAULT_MAX_TOTAL_TOKENS_RANGE,
+  isActiveStatus,
+} from './labels';
+import {
+  FinishBanner,
+  PlanChecklist,
+  ProgressBar,
+  StatusBadge,
+} from './ai-run-parts';
+import { RunSelector } from './ai-run-selectors';
+import { StartRunForm } from './ai-run-start-form';
+import { RunTranscript } from './ai-run-transcript';
+
+// ─── 本体 ───
+
+/**
+ * 自律エージェント Run のパネル。
+ *
+ * 表示専用コンポーネント（データ取得・ストリーム購読は行わない）。
+ * `run` が未指定なら起動フォーム、指定されていれば進捗・計画・transcript を表示する。
+ */
+export function AiRunPanel({
+  run,
+  isLoadingRun = false,
+  messages = [],
+  streamingContent = null,
+  runs = [],
+  onSelectRun,
+  onNewRun,
+  onStartRun,
+  onStopRun,
+  isStarting = false,
+  isStopping = false,
+  isReconnecting = false,
+  transientError = null,
+  startError = null,
+  models = [],
+  goalMaxLength = 4000,
+  maxStepsRange = DEFAULT_MAX_STEPS_RANGE,
+  maxTotalTokensRange = DEFAULT_MAX_TOTAL_TOKENS_RANGE,
+  className,
+}: AiRunPanelProps) {
+  const isActive = run != null && isActiveStatus(run.status);
+
+  return (
+    <div className={cn('flex h-full min-h-0 flex-col', className)}>
+      <div className="flex items-center justify-between gap-2 border-b px-2 py-1.5">
+        <RunSelector
+          runs={runs}
+          currentRunId={run?.id}
+          onSelectRun={onSelectRun}
+        />
+        {(run != null || isLoadingRun) && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 px-2 text-xs"
+            onClick={onNewRun}
+          >
+            <Plus className="size-3" />
+            新しい実行
+          </Button>
+        )}
+      </div>
+
+      {run == null && isLoadingRun ? (
+        <div className="flex flex-1 items-center justify-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="size-3 animate-spin" />
+          実行を読み込んでいます…
+        </div>
+      ) : run == null ? (
+        <ScrollArea className="min-h-0 flex-1">
+          <StartRunForm
+            onStartRun={onStartRun}
+            isStarting={isStarting}
+            startError={startError}
+            onSelectRun={onSelectRun}
+            models={models}
+            goalMaxLength={goalMaxLength}
+            maxStepsRange={maxStepsRange}
+            maxTotalTokensRange={maxTotalTokensRange}
+          />
+        </ScrollArea>
+      ) : (
+        <>
+          <div className="space-y-3 border-b px-3 py-2">
+            <div className="flex items-start justify-between gap-2">
+              <p className="min-w-0 text-xs whitespace-pre-wrap">{run.goal}</p>
+              <StatusBadge status={run.status} />
+            </div>
+
+            {/* status だけでは成否が判別できないため、終了理由で文言を出し分ける */}
+            {run.finishReason && (
+              <FinishBanner
+                finishReason={run.finishReason}
+                lastError={run.lastError}
+              />
+            )}
+
+            {isReconnecting && (
+              <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <RefreshCw className="size-3 animate-spin" />
+                接続が切れました。再接続しています…
+              </p>
+            )}
+
+            {/* error チャンクは終端ではなく自動リトライされるため、失敗とは書かない */}
+            {transientError && !run.finishReason && (
+              <p className="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-300">
+                <AlertTriangle className="mt-0.5 size-3 shrink-0" />
+                <span className="min-w-0 break-words">
+                  一時的なエラーが発生しました。自動でリトライしています（
+                  {transientError}）
+                </span>
+              </p>
+            )}
+
+            <div className="grid grid-cols-2 gap-3">
+              <ProgressBar
+                label="ステップ"
+                value={run.stepCount}
+                max={run.maxSteps}
+              />
+              <ProgressBar
+                label="トークン（入力＋出力）"
+                value={run.totalTokens}
+                max={run.maxTotalTokens}
+              />
+            </div>
+
+            <div className="flex items-center gap-3 text-[10px] text-muted-foreground tabular-nums">
+              <span>作成ノード {run.createdNodeCount}</span>
+              <span>サブエージェント {run.subagentCount}</span>
+            </div>
+
+            <div className="space-y-1.5">
+              <p className="text-[10px] font-medium text-muted-foreground">
+                計画
+              </p>
+              <PlanChecklist plan={run.plan} />
+            </div>
+          </div>
+
+          <RunTranscript
+            messages={messages}
+            streamingContent={streamingContent}
+            isRunning={isActive}
+          />
+
+          {isActive && (
+            <div className="border-t p-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 w-full gap-1 text-xs"
+                onClick={onStopRun}
+                disabled={isStopping}
+              >
+                {isStopping ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Square className="size-3" />
+                )}
+                {isStopping ? '停止を要求しました…' : '停止'}
+              </Button>
+              {isStopping && (
+                <p className="mt-1 text-center text-[10px] text-muted-foreground">
+                  現在のバッチが終わってから停止します
+                </p>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/features/ai-run-panel/ai-run-parts.tsx
+++ b/packages/ui/src/components/features/ai-run-panel/ai-run-parts.tsx
@@ -1,7 +1,12 @@
 import { AlertTriangle, Check, CircleDashed, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { AiRunFinishReason, AiRunPlanItem, AiRunStatus } from './types';
-import { FINISH_REASON_META, FINISH_TONE_CLASS, STATUS_META } from './labels';
+import {
+  FINISH_REASON_META,
+  FINISH_TONE_CLASS,
+  STATUS_META,
+  UNKNOWN_FINISH_META,
+} from './labels';
 
 export function StatusBadge({ status }: { status: AiRunStatus }) {
   const meta = STATUS_META[status];
@@ -99,10 +104,14 @@ export function FinishBanner({
   finishReason,
   lastError,
 }: {
-  finishReason: AiRunFinishReason;
+  /** null の場合は「理由不明で終了」として扱う（黙って隠さない） */
+  finishReason: AiRunFinishReason | null;
   lastError: string | null;
 }) {
-  const meta = FINISH_REASON_META[finishReason];
+  const meta =
+    finishReason != null
+      ? FINISH_REASON_META[finishReason]
+      : UNKNOWN_FINISH_META;
   return (
     <div
       className={cn(

--- a/packages/ui/src/components/features/ai-run-panel/ai-run-parts.tsx
+++ b/packages/ui/src/components/features/ai-run-panel/ai-run-parts.tsx
@@ -1,0 +1,127 @@
+import { AlertTriangle, Check, CircleDashed, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { AiRunFinishReason, AiRunPlanItem, AiRunStatus } from './types';
+import { FINISH_REASON_META, FINISH_TONE_CLASS, STATUS_META } from './labels';
+
+export function StatusBadge({ status }: { status: AiRunStatus }) {
+  const meta = STATUS_META[status];
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium',
+        meta.className,
+      )}
+    >
+      {status === 'running' && <Loader2 className="size-3 animate-spin" />}
+      {meta.label}
+    </span>
+  );
+}
+
+export function ProgressBar({
+  label,
+  value,
+  max,
+  note,
+}: {
+  label: string;
+  value: number;
+  max: number | null;
+  note?: string;
+}) {
+  const percent =
+    max != null && max > 0 ? Math.min(Math.round((value / max) * 100), 100) : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-[10px] font-medium text-muted-foreground">
+          {label}
+        </span>
+        <span className="text-xs tabular-nums">
+          {value.toLocaleString()} / {max != null ? max.toLocaleString() : '—'}
+        </span>
+      </div>
+      <div
+        className="h-1.5 overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-label={label}
+        aria-valuenow={value}
+        aria-valuemin={0}
+        {...(max != null ? { 'aria-valuemax': max } : {})}
+      >
+        <div
+          className={cn(
+            'h-full rounded-full transition-[width]',
+            percent >= 90 ? 'bg-destructive' : 'bg-primary',
+          )}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      {note && <p className="text-[10px] text-muted-foreground">{note}</p>}
+    </div>
+  );
+}
+
+export function PlanChecklist({ plan }: { plan: AiRunPlanItem[] }) {
+  if (plan.length === 0) {
+    return <p className="text-xs text-muted-foreground">計画を立てています…</p>;
+  }
+  return (
+    <ol className="space-y-1.5">
+      {plan.map((item, index) => (
+        // key は index を使う。PlanItem.id は `${runId}-plan-${index}` の
+        // インデックス採番で、計画更新は全上書きのため項目が入れ替わると
+        // 同じ id が別内容を指してしまう。
+        <li key={index} className="flex items-start gap-2 text-xs">
+          {item.status === 'completed' ? (
+            <Check className="mt-0.5 size-3.5 shrink-0 text-green-600" />
+          ) : item.status === 'in_progress' ? (
+            <Loader2 className="mt-0.5 size-3.5 shrink-0 animate-spin text-primary" />
+          ) : (
+            <CircleDashed className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <span
+            className={cn(
+              'min-w-0 whitespace-pre-wrap',
+              item.status === 'completed' && 'text-muted-foreground',
+              item.status === 'in_progress' && 'font-medium',
+            )}
+          >
+            {item.status === 'in_progress' ? item.activeForm : item.content}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export function FinishBanner({
+  finishReason,
+  lastError,
+}: {
+  finishReason: AiRunFinishReason;
+  lastError: string | null;
+}) {
+  const meta = FINISH_REASON_META[finishReason];
+  return (
+    <div
+      className={cn(
+        'space-y-1 rounded-md border px-3 py-2',
+        FINISH_TONE_CLASS[meta.tone],
+      )}
+    >
+      <p className="flex items-center gap-1.5 text-xs font-semibold">
+        {meta.tone === 'success' ? (
+          <Check className="size-3.5" />
+        ) : (
+          <AlertTriangle className="size-3.5" />
+        )}
+        {meta.label}
+      </p>
+      <p className="text-xs">{meta.description}</p>
+      {lastError && (
+        <p className="text-xs break-words opacity-80">{lastError}</p>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/features/ai-run-panel/ai-run-selectors.tsx
+++ b/packages/ui/src/components/features/ai-run-panel/ai-run-selectors.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import { Bot, Check, ChevronDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
+import type { AiModelOption } from '@/components/features/ai-panel/ai-panel';
+import type { AiRunSummary } from './types';
+import { StatusBadge } from './ai-run-parts';
+
+export function RunSelector({
+  runs,
+  currentRunId,
+  onSelectRun,
+}: {
+  runs: AiRunSummary[];
+  currentRunId?: string;
+  onSelectRun?: (runId: string) => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const current = runs.find((run) => run.id === currentRunId);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 min-w-0 gap-1 px-2 text-xs"
+        >
+          <span className="truncate">
+            {current ? current.goal : '実行履歴'}
+          </span>
+          <ChevronDown className="size-3 shrink-0" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-72 p-1">
+        {runs.length === 0 ? (
+          <p className="px-2 py-3 text-center text-xs text-muted-foreground">
+            実行履歴はありません
+          </p>
+        ) : (
+          <ScrollArea className="h-64">
+            <div className="space-y-0.5">
+              {runs.map((run) => (
+                <button
+                  key={run.id}
+                  type="button"
+                  className={cn(
+                    'flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-accent',
+                    run.id === currentRunId && 'bg-accent',
+                  )}
+                  onClick={() => {
+                    onSelectRun?.(run.id);
+                    setOpen(false);
+                  }}
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="line-clamp-2">{run.goal}</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {run.createdAt.toLocaleString()}
+                    </span>
+                  </span>
+                  <StatusBadge status={run.status} />
+                </button>
+              ))}
+            </div>
+          </ScrollArea>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function ModelSelector({
+  models,
+  model,
+  onModelChange,
+}: {
+  models: AiModelOption[];
+  model?: string;
+  onModelChange: (model: string) => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const current = models.find((m) => m.value === model);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 px-2 text-xs"
+        >
+          <Bot className="size-3" />
+          {current?.label ?? 'モデル既定'}
+          <ChevronDown className="size-3" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-48 p-1">
+        <div className="space-y-0.5">
+          {models.map((option) => (
+            <Button
+              key={option.value}
+              type="button"
+              variant={option.value === model ? 'secondary' : 'ghost'}
+              size="sm"
+              className="h-7 w-full justify-start gap-2 px-2 text-xs"
+              onClick={() => {
+                onModelChange(option.value);
+                setOpen(false);
+              }}
+            >
+              {option.value === model ? (
+                <Check className="size-3" />
+              ) : (
+                <span className="size-3" />
+              )}
+              {option.label}
+            </Button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/ui/src/components/features/ai-run-panel/ai-run-start-form.tsx
+++ b/packages/ui/src/components/features/ai-run-panel/ai-run-start-form.tsx
@@ -45,19 +45,21 @@ export function StartRunForm({
   goalMaxLength,
   maxStepsRange,
   maxTotalTokensRange,
+  initialGoal,
 }: {
   onStartRun?: (input: AiRunStartInput) => void;
   isStarting: boolean;
   startError?: AiRunStartError | null;
   onSelectRun?: (runId: string) => void;
   models: AiModelOption[];
+  initialGoal?: string;
   goalMaxLength: number;
   maxStepsRange: { min: number; max: number; default: number };
   maxTotalTokensRange: { min: number; max: number; default: number };
 }) {
   const maxStepsId = React.useId();
   const maxTotalTokensId = React.useId();
-  const [goal, setGoal] = React.useState('');
+  const [goal, setGoal] = React.useState(initialGoal ?? '');
   const [model, setModel] = React.useState<string | undefined>();
   const [maxSteps, setMaxSteps] = React.useState(maxStepsRange.default);
   const [maxTotalTokens, setMaxTotalTokens] = React.useState(
@@ -71,19 +73,28 @@ export function StartRunForm({
     trimmedGoal.length <= goalMaxLength &&
     !isStarting;
 
+  const clamp = (value: number, min: number, max: number) =>
+    Math.min(Math.max(value, min), max);
+
+  /** 空欄・NaN・範囲外を既定値と範囲に丸める */
+  const normalize = (
+    value: number,
+    range: { min: number; max: number; default: number },
+  ) =>
+    clamp(Number.isFinite(value) ? value : range.default, range.min, range.max);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!canStart) return;
+    // number input で Enter 送信すると blur が発生せず未丸めの値が残るため、
+    // 送信時にも必ず正規化する（そのままだとバックエンドで 422 になる）
     onStartRun?.({
       goal: trimmedGoal,
       ...(model ? { model } : {}),
-      maxSteps,
-      maxTotalTokens,
+      maxSteps: normalize(maxSteps, maxStepsRange),
+      maxTotalTokens: normalize(maxTotalTokens, maxTotalTokensRange),
     });
   };
-
-  const clamp = (value: number, min: number, max: number) =>
-    Math.min(Math.max(value, min), max);
 
   return (
     <form onSubmit={handleSubmit} className="space-y-3 p-3">

--- a/packages/ui/src/components/features/ai-run-panel/ai-run-start-form.tsx
+++ b/packages/ui/src/components/features/ai-run-panel/ai-run-start-form.tsx
@@ -1,0 +1,215 @@
+import * as React from 'react';
+import { Loader2, Play } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { isIMEActive } from '@/lib/keyboard-utils';
+import type { AiModelOption } from '@/components/features/ai-panel/ai-panel';
+import type { AiRunStartError, AiRunStartInput } from './types';
+import { ModelSelector } from './ai-run-selectors';
+
+// ─── 起動フォーム ───
+
+/** 起動失敗の通知。409 のときは進行中 Run への導線を出す */
+function StartErrorNotice({
+  error,
+  onSelectRun,
+}: {
+  error: AiRunStartError;
+  onSelectRun?: (runId: string) => void;
+}) {
+  const runningRunId = error.runningRunId;
+  return (
+    <div className="space-y-2 rounded-md border border-destructive/30 bg-destructive/10 p-2.5">
+      <p className="text-xs text-destructive">{error.message}</p>
+      {runningRunId && (
+        <Button
+          type="button"
+          variant="outline"
+          size="xs"
+          onClick={() => onSelectRun?.(runningRunId)}
+        >
+          進行中の実行を見る
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export function StartRunForm({
+  onStartRun,
+  isStarting,
+  startError,
+  onSelectRun,
+  models,
+  goalMaxLength,
+  maxStepsRange,
+  maxTotalTokensRange,
+}: {
+  onStartRun?: (input: AiRunStartInput) => void;
+  isStarting: boolean;
+  startError?: AiRunStartError | null;
+  onSelectRun?: (runId: string) => void;
+  models: AiModelOption[];
+  goalMaxLength: number;
+  maxStepsRange: { min: number; max: number; default: number };
+  maxTotalTokensRange: { min: number; max: number; default: number };
+}) {
+  const maxStepsId = React.useId();
+  const maxTotalTokensId = React.useId();
+  const [goal, setGoal] = React.useState('');
+  const [model, setModel] = React.useState<string | undefined>();
+  const [maxSteps, setMaxSteps] = React.useState(maxStepsRange.default);
+  const [maxTotalTokens, setMaxTotalTokens] = React.useState(
+    maxTotalTokensRange.default,
+  );
+
+  const trimmedGoal = goal.trim();
+  // 二重送信抑止: 送信中とゴール未入力・文字数超過では起動できない
+  const canStart =
+    trimmedGoal.length > 0 &&
+    trimmedGoal.length <= goalMaxLength &&
+    !isStarting;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canStart) return;
+    onStartRun?.({
+      goal: trimmedGoal,
+      ...(model ? { model } : {}),
+      maxSteps,
+      maxTotalTokens,
+    });
+  };
+
+  const clamp = (value: number, min: number, max: number) =>
+    Math.min(Math.max(value, min), max);
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3 p-3">
+      <div className="space-y-1">
+        <p className="text-sm font-semibold">自律実行</p>
+        <p className="text-xs text-muted-foreground">
+          ゴールを渡すと、AIが自分で計画を立てて複数ステップを自動実行します。
+          作成された内容は「検討中」として保存されます。
+        </p>
+      </div>
+
+      {startError && (
+        <StartErrorNotice error={startError} onSelectRun={onSelectRun} />
+      )}
+
+      <div className="space-y-1">
+        <Textarea
+          value={goal}
+          onChange={(e) => setGoal(e.target.value)}
+          placeholder="例: 第2章のプロットを整理して、登場人物の設定と矛盾がないようにメモを作成する"
+          rows={4}
+          maxLength={goalMaxLength}
+          className="min-h-[96px] text-sm"
+          onKeyDown={(e) => {
+            if (
+              e.key === 'Enter' &&
+              (e.metaKey || e.ctrlKey) &&
+              !isIMEActive(e)
+            ) {
+              e.preventDefault();
+              handleSubmit(e);
+            }
+          }}
+        />
+        <p className="text-right text-[10px] text-muted-foreground tabular-nums">
+          {trimmedGoal.length} / {goalMaxLength.toLocaleString()}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div className="space-y-1">
+          <label
+            htmlFor={maxStepsId}
+            className="block text-[10px] font-medium text-muted-foreground"
+          >
+            最大ステップ数
+          </label>
+          <Input
+            id={maxStepsId}
+            type="number"
+            inputMode="numeric"
+            min={maxStepsRange.min}
+            max={maxStepsRange.max}
+            value={maxSteps}
+            onChange={(e) => setMaxSteps(Number(e.target.value))}
+            onBlur={(e) =>
+              setMaxSteps(
+                clamp(
+                  Number(e.target.value) || maxStepsRange.default,
+                  maxStepsRange.min,
+                  maxStepsRange.max,
+                ),
+              )
+            }
+            className="h-8 text-xs tabular-nums"
+          />
+        </div>
+        <div className="space-y-1">
+          <label
+            htmlFor={maxTotalTokensId}
+            className="block text-[10px] font-medium text-muted-foreground"
+          >
+            トークン予算
+          </label>
+          <Input
+            id={maxTotalTokensId}
+            type="number"
+            inputMode="numeric"
+            min={maxTotalTokensRange.min}
+            max={maxTotalTokensRange.max}
+            step={1000}
+            value={maxTotalTokens}
+            onChange={(e) => setMaxTotalTokens(Number(e.target.value))}
+            onBlur={(e) =>
+              setMaxTotalTokens(
+                clamp(
+                  Number(e.target.value) || maxTotalTokensRange.default,
+                  maxTotalTokensRange.min,
+                  maxTotalTokensRange.max,
+                ),
+              )
+            }
+            className="h-8 text-xs tabular-nums"
+          />
+        </div>
+      </div>
+      <p className="text-[10px] text-muted-foreground">
+        トークン予算は<strong>出力だけでなく入力を含む合計</strong>です。
+        毎回のバッチでコンテキスト全文を再送するため、入力は出力の10〜30倍になることがあります。
+        小さすぎる値を設定するとすぐに打ち切られます。
+      </p>
+
+      <div className="flex items-center justify-between gap-2">
+        {models.length > 0 ? (
+          <ModelSelector
+            models={models}
+            model={model}
+            onModelChange={setModel}
+          />
+        ) : (
+          <span />
+        )}
+        <Button
+          type="submit"
+          size="sm"
+          className="h-7 gap-1 px-3 text-xs"
+          disabled={!canStart}
+        >
+          {isStarting ? (
+            <Loader2 className="size-3 animate-spin" />
+          ) : (
+            <Play className="size-3" />
+          )}
+          {isStarting ? '起動中…' : '実行開始'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/packages/ui/src/components/features/ai-run-panel/ai-run-transcript.tsx
+++ b/packages/ui/src/components/features/ai-run-panel/ai-run-transcript.tsx
@@ -19,7 +19,13 @@ function EditMessageRow({ message }: { message: AiRunEditMessage }) {
       )}
       <span className="min-w-0 truncate">
         [{typeLabel}] {message.targetName} を
-        {EDIT_ACTION_LABELS[message.action]}しました
+        {EDIT_ACTION_LABELS[message.action]}
+        {/* 編集保護やコンフリクトで弾かれた場合に「しました」と書かない */}
+        {message.status === 'accepted' || message.status === 'pending'
+          ? 'しました'
+          : message.status === 'conflict'
+            ? 'できませんでした（コンフリクト）'
+            : 'できませんでした'}
       </span>
     </div>
   );
@@ -85,7 +91,9 @@ export function RunTranscript({
         {streamingContent !== null && streamingContent !== '' && (
           <Markdown className="text-sm">{streamingContent}</Markdown>
         )}
-        {isRunning && streamingContent === '' && (
+        {/* バッチ間（LLM 待ち・リトライの無音区間）で無反応に見えないようにする。
+            streamingContent は null にも '' にもなり得るので両方を拾う。 */}
+        {!isEmpty && isRunning && !streamingContent && (
           <p className="text-sm text-muted-foreground animate-pulse">
             考えています...
           </p>

--- a/packages/ui/src/components/features/ai-run-panel/ai-run-transcript.tsx
+++ b/packages/ui/src/components/features/ai-run-panel/ai-run-transcript.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { FilePenLine, FilePlus2 } from 'lucide-react';
+import { Markdown } from '@/components/ui/markdown';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { AiRunEditMessage, AiRunMessage } from './types';
+import { CONTENT_TYPE_LABELS, EDIT_ACTION_LABELS } from './labels';
+
+// ─── transcript ───
+
+function EditMessageRow({ message }: { message: AiRunEditMessage }) {
+  const typeLabel =
+    CONTENT_TYPE_LABELS[message.contentType] ?? message.contentType;
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      {message.action === 'create' ? (
+        <FilePlus2 className="size-3.5 shrink-0" />
+      ) : (
+        <FilePenLine className="size-3.5 shrink-0" />
+      )}
+      <span className="min-w-0 truncate">
+        [{typeLabel}] {message.targetName} を
+        {EDIT_ACTION_LABELS[message.action]}しました
+      </span>
+    </div>
+  );
+}
+
+export function RunTranscript({
+  messages,
+  streamingContent,
+  isRunning,
+}: {
+  messages: AiRunMessage[];
+  streamingContent: string | null;
+  isRunning: boolean;
+}) {
+  const viewportRef = React.useRef<HTMLDivElement | null>(null);
+  const isAtBottomRef = React.useRef(true);
+
+  React.useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const handleScroll = () => {
+      const distance =
+        viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+      isAtBottomRef.current = distance < 30;
+    };
+    viewport.addEventListener('scroll', handleScroll, { passive: true });
+    return () => viewport.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  React.useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || !isAtBottomRef.current) return;
+    viewport.scrollTop = viewport.scrollHeight;
+  }, [messages, streamingContent]);
+
+  const isEmpty = messages.length === 0 && streamingContent === null;
+
+  return (
+    <ScrollArea className="min-h-0 flex-1" viewportRef={viewportRef}>
+      <div className="space-y-3 px-3 py-2">
+        {isEmpty ? (
+          <p className="py-4 text-center text-xs text-muted-foreground">
+            {isRunning ? '実行を開始しました…' : '記録はありません'}
+          </p>
+        ) : (
+          messages.map((message) =>
+            message.kind === 'edit' ? (
+              <EditMessageRow key={message.id} message={message} />
+            ) : message.role === 'user' ? (
+              <div
+                key={message.id}
+                className="w-full rounded-lg border px-3 py-1.5"
+              >
+                <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+              </div>
+            ) : (
+              <Markdown key={message.id} className="text-sm">
+                {message.content}
+              </Markdown>
+            ),
+          )
+        )}
+        {streamingContent !== null && streamingContent !== '' && (
+          <Markdown className="text-sm">{streamingContent}</Markdown>
+        )}
+        {isRunning && streamingContent === '' && (
+          <p className="text-sm text-muted-foreground animate-pulse">
+            考えています...
+          </p>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/packages/ui/src/components/features/ai-run-panel/index.ts
+++ b/packages/ui/src/components/features/ai-run-panel/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './ai-run-panel';

--- a/packages/ui/src/components/features/ai-run-panel/labels.ts
+++ b/packages/ui/src/components/features/ai-run-panel/labels.ts
@@ -1,0 +1,113 @@
+import type { AiRunEditMessage, AiRunFinishReason, AiRunStatus } from './types';
+
+// ─── ラベル定義 ───
+
+export const STATUS_META: Record<
+  AiRunStatus,
+  { label: string; className: string }
+> = {
+  queued: { label: '待機中', className: 'bg-muted text-muted-foreground' },
+  running: { label: '実行中', className: 'bg-primary/10 text-primary' },
+  paused: { label: '一時停止', className: 'bg-muted text-muted-foreground' },
+  completed: { label: '終了', className: 'bg-muted text-muted-foreground' },
+  stopped: { label: '停止', className: 'bg-muted text-muted-foreground' },
+  error: { label: 'エラー', className: 'bg-destructive/10 text-destructive' },
+};
+
+export type FinishTone = 'success' | 'warning' | 'danger' | 'neutral';
+
+/**
+ * 終了理由ごとの文言。
+ *
+ * `status: 'completed'` は「成功」を意味せず、打ち切りも completed になるため、
+ * ユーザーに見せる文言は必ずこの表で出し分ける。
+ */
+export const FINISH_REASON_META: Record<
+  AiRunFinishReason,
+  { label: string; description: string; tone: FinishTone }
+> = {
+  agent_completed: {
+    label: '完了しました',
+    description: 'AIが目標を達成したと判断して終了しました。',
+    tone: 'success',
+  },
+  completed_plan: {
+    label: '完了しました',
+    description: '計画のすべての項目を消化して終了しました。',
+    tone: 'success',
+  },
+  max_steps: {
+    label: 'ステップ上限で打ち切りました',
+    description:
+      'ステップ数の上限に達したため途中で終了しています。続きを実行するには、上限を増やして再実行してください。',
+    tone: 'warning',
+  },
+  max_tokens: {
+    label: 'トークン上限で打ち切りました',
+    description:
+      'トークン予算の上限に達したため途中で終了しています。続きを実行するには、予算を増やして再実行してください。',
+    tone: 'warning',
+  },
+  node_limit: {
+    label: 'ノード作成上限で打ち切りました',
+    description:
+      '1回の実行で作成できるノード数の上限（40件）に達したため終了しています。',
+    tone: 'warning',
+  },
+  diminishing_returns: {
+    label: '進捗が出なくなり停止しました',
+    description:
+      'これ以上進捗が出ないと判断して停止しています。ゴールを具体的にして再実行すると改善することがあります。',
+    tone: 'warning',
+  },
+  stopped: {
+    label: '停止しました',
+    description: '操作により停止しました。',
+    tone: 'neutral',
+  },
+  error: {
+    label: 'エラーで終了しました',
+    description: 'エラーが発生したため終了しています。',
+    tone: 'danger',
+  },
+  interrupted: {
+    label: '中断されました',
+    description:
+      'サーバーの再起動などで中断されました。自動では再開しないため、必要であれば再実行してください。',
+    tone: 'danger',
+  },
+};
+
+export const FINISH_TONE_CLASS: Record<FinishTone, string> = {
+  success:
+    'border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300',
+  warning:
+    'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+  danger: 'border-destructive/30 bg-destructive/10 text-destructive',
+  neutral: 'border-border bg-muted/50 text-muted-foreground',
+};
+
+export const EDIT_ACTION_LABELS: Record<AiRunEditMessage['action'], string> = {
+  create: '作成',
+  update: '更新',
+};
+
+export const CONTENT_TYPE_LABELS: Record<string, string> = {
+  plot: 'プロット',
+  character: 'キャラクター',
+  memo: 'メモ',
+  writing: '本文',
+  project: 'プロジェクト',
+};
+
+export const DEFAULT_MAX_STEPS_RANGE = { min: 1, max: 200, default: 60 };
+export const DEFAULT_MAX_TOTAL_TOKENS_RANGE = {
+  min: 1000,
+  max: 5_000_000,
+  default: 2_000_000,
+};
+
+/** 実行が続いている（停止操作が意味を持つ）ステータス */
+export function isActiveStatus(status: AiRunStatus): boolean {
+  return status === 'queued' || status === 'running' || status === 'paused';
+}

--- a/packages/ui/src/components/features/ai-run-panel/labels.ts
+++ b/packages/ui/src/components/features/ai-run-panel/labels.ts
@@ -111,3 +111,20 @@ export const DEFAULT_MAX_TOTAL_TOKENS_RANGE = {
 export function isActiveStatus(status: AiRunStatus): boolean {
   return status === 'queued' || status === 'running' || status === 'paused';
 }
+
+/**
+ * 終了理由が未知（バックエンドが新しい値を追加した）の場合に使う文言。
+ *
+ * `status` が終了系なのに理由が判別できないとき、バナーを出さずに黙って
+ * 「終了」だけ見せると成功と誤解されるため、必ず何か出す。
+ */
+export const UNKNOWN_FINISH_META: {
+  label: string;
+  description: string;
+  tone: FinishTone;
+} = {
+  label: '終了しました',
+  description:
+    '終了理由を判別できませんでした。成功したとは限らないため、内容を確認してください。',
+  tone: 'warning',
+};

--- a/packages/ui/src/components/features/ai-run-panel/types.ts
+++ b/packages/ui/src/components/features/ai-run-panel/types.ts
@@ -46,6 +46,11 @@ export interface AiRunEditMessage {
   action: 'create' | 'update';
   contentType: string;
   targetName: string;
+  /**
+   * 適用結果。`accepted` 以外（編集保護やコンフリクトで弾かれた場合）は
+   * 「適用しました」と書かないための情報。
+   */
+  status: 'pending' | 'accepted' | 'rejected' | 'conflict';
 }
 
 export type AiRunMessage = AiRunTextMessage | AiRunEditMessage;
@@ -102,8 +107,13 @@ export interface AiRunPanelProps {
   /** 過去の Run 一覧（新しい順） */
   runs?: AiRunSummary[];
   onSelectRun?: (runId: string) => void;
-  /** 新しい実行を作る（起動フォームに戻す） */
-  onNewRun?: () => void;
+  /**
+   * 新しい実行を作る（起動フォームに戻す）。
+   * 打ち切られた Run の続きを実行しやすくするため、表示中のゴールを渡す。
+   */
+  onNewRun?: (prefillGoal?: string) => void;
+  /** 起動フォームのゴール初期値（打ち切り後の再実行用） */
+  initialGoal?: string;
   onStartRun?: (input: AiRunStartInput) => void;
   onStopRun?: () => void;
   /** 起動リクエスト中（二重送信抑止に使う） */
@@ -112,6 +122,15 @@ export interface AiRunPanelProps {
   isStopping?: boolean;
   /** ストリーム切断からの再接続待機中 */
   isReconnecting?: boolean;
+  /**
+   * 購読を打ち切ったときのエラー（復旧しない）。
+   * `transientError` と違い、ユーザーに再接続を促す。
+   */
+  fatalError?: string | null;
+  /** `fatalError` からの再接続 */
+  onRetryConnection?: () => void;
+  /** Run の取得自体に失敗したときのメッセージ */
+  loadError?: string | null;
   /**
    * リトライ中のエラー。
    * 自律Run の `error` は終端ではなく自動リトライされるため、

--- a/packages/ui/src/components/features/ai-run-panel/types.ts
+++ b/packages/ui/src/components/features/ai-run-panel/types.ts
@@ -1,0 +1,132 @@
+import type { AiModelOption } from '@/components/features/ai-panel/ai-panel';
+
+// ─── 型（packages/ui は adapter に依存しないため独自定義） ───
+
+export type AiRunStatus =
+  | 'queued'
+  | 'running'
+  | 'paused'
+  | 'completed'
+  | 'stopped'
+  | 'error';
+
+export type AiRunFinishReason =
+  | 'agent_completed'
+  | 'completed_plan'
+  | 'max_steps'
+  | 'max_tokens'
+  | 'node_limit'
+  | 'diminishing_returns'
+  | 'stopped'
+  | 'error'
+  | 'interrupted';
+
+export type AiRunPlanItemStatus = 'pending' | 'in_progress' | 'completed';
+
+export interface AiRunPlanItem {
+  /** 命令形の内容 */
+  content: string;
+  /** 進行形の表示（実行中の項目はこちらを表示する） */
+  activeForm: string;
+  status: AiRunPlanItemStatus;
+}
+
+/** transcript のテキストメッセージ */
+export interface AiRunTextMessage {
+  id: string;
+  kind: 'text';
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/** AI が適用した編集（自律Runでは承認を挟まず即座に保存される） */
+export interface AiRunEditMessage {
+  id: string;
+  kind: 'edit';
+  action: 'create' | 'update';
+  contentType: string;
+  targetName: string;
+}
+
+export type AiRunMessage = AiRunTextMessage | AiRunEditMessage;
+
+/** 表示中の Run の状態 */
+export interface AiRunDetail {
+  id: string;
+  goal: string;
+  status: AiRunStatus;
+  finishReason: AiRunFinishReason | null;
+  plan: AiRunPlanItem[];
+  stepCount: number;
+  maxSteps: number;
+  totalTokens: number;
+  maxTotalTokens: number | null;
+  createdNodeCount: number;
+  subagentCount: number;
+  lastError: string | null;
+}
+
+/** Run 一覧の項目 */
+export interface AiRunSummary {
+  id: string;
+  goal: string;
+  status: AiRunStatus;
+  finishReason: AiRunFinishReason | null;
+  createdAt: Date;
+}
+
+/** 起動フォームの入力値 */
+export interface AiRunStartInput {
+  goal: string;
+  model?: string;
+  maxSteps: number;
+  maxTotalTokens: number;
+}
+
+/** 起動に失敗したときの表示情報 */
+export interface AiRunStartError {
+  message: string;
+  /** 進行中 Run のID（409 時）。指定すると「進行中の実行を見る」導線を出す */
+  runningRunId?: string;
+}
+
+export interface AiRunPanelProps {
+  /** 表示中の Run。未指定なら起動フォームを表示する */
+  run?: AiRunDetail | null;
+  /** Run の取得中（`run` が未確定でも起動フォームに戻さない） */
+  isLoadingRun?: boolean;
+  /** transcript（表示用に整形済み） */
+  messages?: AiRunMessage[];
+  /** ストリーミング中のテキスト（未確定のアシスタント発言） */
+  streamingContent?: string | null;
+  /** 過去の Run 一覧（新しい順） */
+  runs?: AiRunSummary[];
+  onSelectRun?: (runId: string) => void;
+  /** 新しい実行を作る（起動フォームに戻す） */
+  onNewRun?: () => void;
+  onStartRun?: (input: AiRunStartInput) => void;
+  onStopRun?: () => void;
+  /** 起動リクエスト中（二重送信抑止に使う） */
+  isStarting?: boolean;
+  /** 停止リクエスト中 */
+  isStopping?: boolean;
+  /** ストリーム切断からの再接続待機中 */
+  isReconnecting?: boolean;
+  /**
+   * リトライ中のエラー。
+   * 自律Run の `error` は終端ではなく自動リトライされるため、
+   * 「失敗」ではなく「リトライ中」として表示する。
+   */
+  transientError?: string | null;
+  /** 起動時のエラー（同時実行の 409 等） */
+  startError?: AiRunStartError | null;
+  /** 選択可能なモデル一覧（省略・空の場合はモデル選択UIを出さない） */
+  models?: AiModelOption[];
+  /** ゴールの最大文字数 */
+  goalMaxLength?: number;
+  /** ステップ上限の入力範囲と既定値 */
+  maxStepsRange?: { min: number; max: number; default: number };
+  /** トークン予算の入力範囲と既定値 */
+  maxTotalTokensRange?: { min: number; max: number; default: number };
+  className?: string;
+}

--- a/packages/ui/src/components/features/index.ts
+++ b/packages/ui/src/components/features/index.ts
@@ -1,5 +1,6 @@
 export * from './ai-memory';
 export * from './ai-panel';
+export * from './ai-run-panel';
 export * from './ai-usage';
 export * from './consistency-check';
 export * from './context-preview';


### PR DESCRIPTION
## 概要

AIが自分で計画を立てて複数ステップを自動実行する **自律Run** を、対話チャットとは別系統のUIとして追加した。バックエンド v1.3.1 で追加された Run API（`createAIRun` / `getAIRuns` / `getAIRun` / `getAIRunMessages` / `streamAIRun` / `stopAIRun`）に接続する。

AIパネル右側に「自律実行」タブを追加し、ゴール入力 → 計画・進捗の追跡 → 停止までを1画面で扱えるようにした。

## レイヤー構成

| レイヤー | 追加物 |
|---|---|
| `adapter-core` | `AIRun` / `AIRunPlanItem` / `AIRunStreamChunk` / `CreateAIRunResult` と `AIRunAdapter` IF（types.ts → adapter.ts → stub.ts の順） |
| `adapter-api` | `AiRunsApi` を `ApiClients` に登録し `adapters/run.ts` を実装。SSE 正規化・再接続は `internal/helpers/run.ts` にピュアロジックとして分離 |
| `packages/ui` | 表示専用の `AiRunPanel`（adapter 非依存の独自型 + Story 7本） |
| `apps/desktop` | SWR hooks（`hooks/ai-runs.ts`）+ ストリーム購読のグルー |

対話チャットの SSE とセマンティクスが異なるため、`toAIStreamChunk` は流用せず `toAIRunStreamChunk` を別実装にしている。

## ハマりどころへの対応

仕様上の落とし穴に、それぞれ意図をコメントに残して対応した。

### 409（同時実行）を型で強制する
`createAIRun` には `@ApiConflictResponse` が無く、**生成クライアントの型に 409 が現れない**。握り潰しを防ぐため例外にせず `CreateAIRunResult`（`status: 'created' | 'conflict'`）で表現し、呼び出し側に分岐を強制した。進行中 Run への導線ボタンを出し、送信中は起動ボタンを無効化（＋ハンドラ側でも早期 return）して二重送信を抑止する。パネルを開いた時点で進行中 Run があれば自動で開く。

### `status: 'completed'` は成功ではない
打ち切りも `completed` になるため、文言は必ず `finishReason` で出し分ける。9種すべてを `FINISH_REASON_META` に定義し、成功／打ち切り／停止／エラーで色と説明を変える。`interrupted` は自動再開しないので再実行を促す。`paused` は型としてのみ受ける。

### 終端判定と `error` の扱い
- Run には `finish` チャンクが流れないため、**終端は `run-status` かつ `finishReason` を持つチャンクのみ**
- それ以外でストリームが閉じたら切断とみなしてバックオフ再接続
- **`error` は終端ではない**（サーバーが最大2回リトライ）ため「失敗」ではなく「リトライ中」と表示する

### リプレイ不可 → transcript を正とする
`Last-Event-ID` による再開ができないため、購読・再接続のたびに `getAIRunMessages` で transcript を取り直してから SSE を購読する。受け取り側は `transcript` チャンクで状態を**置き換える**（追記しない）。`start` チャンクも流れないので、バッチ単体の `usage` チャンクをバッチ境界として transcript を取り直す。累積トークンは `AIRun.totalTokens` から読む。

`proposal` が `tool-call` より先に届くことがあるため、ストリームの到着順では描画せず transcript の順序を正とした。

### 即時保存・停止・進捗表示
- 自律Runのノードは `canonStatus: 'draft'` で即保存されるため、`proposal-result` を受けた時点でツリー／エディタを再取得する（完了を待たない）
- `stopAIRun` のレスポンス `status` は `running` のことがあるため「停止済み」として反映せず、実際に非アクティブになるまで要求中として表示する
- 進捗は `stepCount / maxSteps` と `totalTokens / maxTotalTokens` の2軸
- トークン予算の入力欄に「**出力だけでなく入力を含む合計**」であることを明記（旧実装の感覚で設定すると即打ち切りになるため）
- `PlanItem.id` は `${runId}-plan-${index}` のインデックス採番で全上書きされるため、React の key には index を使う

## リファクタリング

`toMessage` を `internal/helpers/message.ts`、`toProposalFeedback` を `internal/helpers/sse.ts` に切り出し、対話チャットと自律Runで共用するようにした。既存のチャット挙動は変えていない。

## テスト

`internal/helpers/run.spec.ts` に20件追加（既存28件と合わせて adapter-api 48件パス）。

- 型変換: `finish_reason` の既知／未知／null、`plan` の `content` / `active_form`、`proposal-result` からの `target_id` 取り出し、`finish` / `start` / 未知 type のスキップ
- 終端判定: `finishReason` 付き `run-status` のみ終端
- 再接続: 購読開始時に transcript を先に流す／終端前に閉じたら transcript を取り直してから再購読する／`error` チャンクでは再接続しない／SSE 取得自体の失敗でも再接続する／バックオフが末尾の値で頭打ちになる／スナップショットしか来ない場合は試行回数を使い切って `error` で閉じる（無限ループ防止）／進捗があれば試行回数をリセットする／消費側のキャンセルで再接続しない

## テストプラン

- [x] `npm run build`（デスクトップアプリのバンドルまで含めて成功）
- [x] `npm run tsc`
- [x] `npm run lint`（新規エラー・警告なし）
- [x] `npm run test`（67件パス）
- [x] `npm run build-storybook`
- [ ] 実バックエンドに接続して Run を起動し、計画・進捗・transcript がライブ更新されることを確認
- [ ] 進行中に2本目を起動して 409 のメッセージと「進行中の実行を見る」導線が出ることを確認
- [ ] 実行中に停止して、`run-status(stopped)` が届くまで「停止を要求しました…」が出続けることを確認
- [ ] 実行中にネットワークを切って、再接続後に transcript が欠けずに復帰することを確認
- [ ] ノード作成時に、Run 完了を待たずサイドバーのツリーが更新されることを確認
- [ ] `max_steps` を小さくして起動し、打ち切り文言（成功ではない旨）が出ることを確認

## 補足

`packages/adapter/api/package.json` の `@tsumugi-chan/client` は 1.3.1 のままで、依存の更新は不要（Run API は既に含まれている）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)