### PR TITLE
fix: エディタのタイトル欄を本文と同じスクロール領域に含める

### DIFF
--- a/packages/ui/src/components/features/editor/character-editor.tsx
+++ b/packages/ui/src/components/features/editor/character-editor.tsx
@@ -48,23 +48,23 @@ export function CharacterEditor({
 }: CharacterEditorProps) {
   return (
     <div className={cn('flex h-full flex-col bg-background', className)}>
-      {data.name !== undefined && (
-        <div className="flex items-center border-b px-6 py-3">
-          {onChange ? (
-            <input
-              type="text"
-              value={data.name}
-              onChange={(e) => onChange('name', e.target.value)}
-              className="w-full bg-transparent text-lg font-semibold outline-none focus:ring-1 focus:ring-ring rounded px-1"
-              placeholder="キャラクター名を入力..."
-              readOnly={readOnly}
-            />
-          ) : (
-            <h1 className="text-lg font-semibold">{data.name}</h1>
-          )}
-        </div>
-      )}
       <ScrollArea className="flex-1 overflow-hidden">
+        {data.name !== undefined && (
+          <div className="flex items-center border-b px-6 py-3">
+            {onChange ? (
+              <input
+                type="text"
+                value={data.name}
+                onChange={(e) => onChange('name', e.target.value)}
+                className="w-full bg-transparent text-lg font-semibold outline-none focus:ring-1 focus:ring-ring rounded px-1"
+                placeholder="キャラクター名を入力..."
+                readOnly={readOnly}
+              />
+            ) : (
+              <h1 className="text-lg font-semibold">{data.name}</h1>
+            )}
+          </div>
+        )}
         <div className="space-y-5 p-6">
           <div className="grid grid-cols-2 gap-4">
             {shortFields.map(({ key, label }) => (

--- a/packages/ui/src/components/features/editor/memo-editor.tsx
+++ b/packages/ui/src/components/features/editor/memo-editor.tsx
@@ -49,23 +49,23 @@ export function MemoEditor({
 
   return (
     <div className={cn('flex h-full flex-col bg-background', className)}>
-      {name !== undefined && (
-        <div className="flex items-center border-b px-6 py-3">
-          {onNameChange ? (
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => onNameChange(e.target.value)}
-              className="w-full bg-transparent text-lg font-semibold outline-none focus:ring-1 focus:ring-ring rounded px-1"
-              placeholder="メモ名を入力..."
-              readOnly={readOnly}
-            />
-          ) : (
-            <h1 className="text-lg font-semibold">{name}</h1>
-          )}
-        </div>
-      )}
       <ScrollArea className="flex-1 overflow-hidden">
+        {name !== undefined && (
+          <div className="flex items-center border-b px-6 py-3">
+            {onNameChange ? (
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => onNameChange(e.target.value)}
+                className="w-full bg-transparent text-lg font-semibold outline-none focus:ring-1 focus:ring-ring rounded px-1"
+                placeholder="メモ名を入力..."
+                readOnly={readOnly}
+              />
+            ) : (
+              <h1 className="text-lg font-semibold">{name}</h1>
+            )}
+          </div>
+        )}
         <div className="space-y-5 p-6">
           <div className="space-y-1.5">
             <label

--- a/packages/ui/src/components/features/editor/plot-editor.tsx
+++ b/packages/ui/src/components/features/editor/plot-editor.tsx
@@ -39,23 +39,23 @@ export function PlotEditor({
 }: PlotEditorProps) {
   return (
     <div className={cn('flex h-full flex-col bg-background', className)}>
-      {data.name !== undefined && (
-        <div className="flex items-center border-b px-6 py-3">
-          {onChange ? (
-            <input
-              type="text"
-              value={data.name}
-              onChange={(e) => onChange('name', e.target.value)}
-              className="w-full bg-transparent text-lg font-semibold outline-none focus:ring-1 focus:ring-ring rounded px-1"
-              placeholder="プロット名を入力..."
-              readOnly={readOnly}
-            />
-          ) : (
-            <h1 className="text-lg font-semibold">{data.name}</h1>
-          )}
-        </div>
-      )}
       <ScrollArea className="flex-1 overflow-hidden">
+        {data.name !== undefined && (
+          <div className="flex items-center border-b px-6 py-3">
+            {onChange ? (
+              <input
+                type="text"
+                value={data.name}
+                onChange={(e) => onChange('name', e.target.value)}
+                className="w-full bg-transparent text-lg font-semibold outline-none focus:ring-1 focus:ring-ring rounded px-1"
+                placeholder="プロット名を入力..."
+                readOnly={readOnly}
+              />
+            ) : (
+              <h1 className="text-lg font-semibold">{data.name}</h1>
+            )}
+          </div>
+        )}
         <div className="space-y-5 p-6">
           {fields.map(({ key, label }) => (
             <div key={key} className="space-y-1.5">

--- a/packages/ui/src/components/features/editor/project-editor.tsx
+++ b/packages/ui/src/components/features/editor/project-editor.tsx
@@ -59,21 +59,21 @@ export function ProjectEditor({
 }: ProjectEditorProps) {
   return (
     <div className={cn('flex h-full flex-col bg-background', className)}>
-      <div className="flex items-center border-b px-6 py-3">
-        {onChange ? (
-          <input
-            type="text"
-            value={data.name}
-            onChange={(e) => onChange('name', e.target.value)}
-            className="w-full bg-transparent text-lg font-semibold outline-none focus:ring-1 focus:ring-ring rounded px-1"
-            placeholder="作品タイトルを入力..."
-            readOnly={readOnly}
-          />
-        ) : (
-          <h1 className="text-lg font-semibold">{data.name}</h1>
-        )}
-      </div>
       <ScrollArea className="flex-1 overflow-hidden">
+        <div className="flex items-center border-b px-6 py-3">
+          {onChange ? (
+            <input
+              type="text"
+              value={data.name}
+              onChange={(e) => onChange('name', e.target.value)}
+              className="w-full bg-transparent text-lg font-semibold outline-none focus:ring-1 focus:ring-ring rounded px-1"
+              placeholder="作品タイトルを入力..."
+              readOnly={readOnly}
+            />
+          ) : (
+            <h1 className="text-lg font-semibold">{data.name}</h1>
+          )}
+        </div>
         <div className="space-y-5 p-6">
           {textareaFields.map(({ key, label, placeholder, minHeight }) => (
             <div key={key} className="space-y-1.5">

--- a/packages/ui/src/components/features/editor/writing-editor.tsx
+++ b/packages/ui/src/components/features/editor/writing-editor.tsx
@@ -84,23 +84,23 @@ export function WritingEditor({
 
   return (
     <div className={cn('flex h-full flex-col bg-background', className)}>
-      {name !== undefined && (
-        <div className="flex items-center border-b px-6 py-3">
-          {onNameChange ? (
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => onNameChange(e.target.value)}
-              className="w-full bg-transparent text-lg font-semibold outline-none focus:ring-1 focus:ring-ring rounded px-1"
-              placeholder="タイトルを入力..."
-              readOnly={readOnly}
-            />
-          ) : (
-            <h1 className="text-lg font-semibold">{name}</h1>
-          )}
-        </div>
-      )}
       <ScrollArea className="flex-1 overflow-hidden">
+        {name !== undefined && (
+          <div className="flex items-center border-b px-6 py-3">
+            {onNameChange ? (
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => onNameChange(e.target.value)}
+                className="w-full bg-transparent text-lg font-semibold outline-none focus:ring-1 focus:ring-ring rounded px-1"
+                placeholder="タイトルを入力..."
+                readOnly={readOnly}
+              />
+            ) : (
+              <h1 className="text-lg font-semibold">{name}</h1>
+            )}
+          </div>
+        )}
         <div className="p-6">
           <Textarea
             ref={textareaRef}


### PR DESCRIPTION
## 概要

エディタのタイトル入力欄が固定ヘッダーとして `ScrollArea` の外に置かれていたため、本文をスクロールしてもタイトルだけが画面上部に残り続けていました。タイトル行を `ScrollArea` 内の先頭に移動し、本文と同じスクロール対象になるようにしました。

## 変更内容

`packages/ui/src/components/features/editor/` 配下の 5 コンポーネントで、タイトル行の `<div>` を `<ScrollArea>` の外側 → 内側の先頭へ移動:

- `writing-editor.tsx`
- `plot-editor.tsx`
- `character-editor.tsx`
- `memo-editor.tsx`
- `project-editor.tsx`

```diff
-  {name !== undefined && (
-    <div className="flex items-center border-b px-6 py-3"> ... </div>
-  )}
   <ScrollArea className="flex-1 overflow-hidden">
+    {name !== undefined && (
+      <div className="flex items-center border-b px-6 py-3"> ... </div>
+    )}
     <div className="p-6"> ... </div>
   </ScrollArea>
```

- マークアップ・クラス構成はそのまま（`border-b` の区切り線も維持）なので、スクロール最上部での見た目は従来と同一です。
- 外枠の `flex h-full flex-col` / フッター（文字数バー・エクスポートボタン）の固定表示は変更なし。
- `apps/desktop` 側の属性バー（`node-attributes-bar.tsx`）は引き続き固定ヘッダーのままです。

## 動作確認

- [x] `packages/ui` の `tsc --noEmit` パス
- [ ] Storybook で各エディタ（Default / Empty / Interactive）を開き、本文をスクロールするとタイトルも一緒に流れることを確認
- [ ] デスクトップアプリのワークスペースで Writing / Plot / Character / Memo / Project の各エディタを確認
- [ ] タイトル入力欄へのフォーカス・IME 入力が従来どおり動作すること